### PR TITLE
device: add support to configure eee

### DIFF
--- a/device.c
+++ b/device.c
@@ -74,6 +74,7 @@ static const struct blobmsg_policy dev_attrs[__DEV_ATTR_MAX] = {
 	[DEV_ATTR_AUTONEG] = { .name = "autoneg", .type = BLOBMSG_TYPE_BOOL },
 	[DEV_ATTR_GRO] = { .name = "gro", .type = BLOBMSG_TYPE_BOOL },
 	[DEV_ATTR_MASTER] = { .name = "conduit", .type = BLOBMSG_TYPE_STRING },
+	[DEV_ATTR_EEE] = { .name = "eee", .type = BLOBMSG_TYPE_BOOL },
 };
 
 const struct uci_blob_param_list device_attr_list = {
@@ -299,6 +300,7 @@ device_merge_settings(struct device *dev, struct device_settings *n)
 	n->txpause = s->flags & DEV_OPT_TXPAUSE ? s->txpause : os->txpause;
 	n->autoneg = s->flags & DEV_OPT_AUTONEG ? s->autoneg : os->autoneg;
 	n->gro = s->flags & DEV_OPT_GRO ? s->gro : os->gro;
+	n->eee = s->flags & DEV_OPT_EEE ? s->eee : os->eee;
 	n->master_ifindex = s->flags & DEV_OPT_MASTER ? s->master_ifindex : os->master_ifindex;
 	n->flags = s->flags | os->flags | os->valid_flags;
 }
@@ -559,6 +561,11 @@ device_init_settings(struct device *dev, struct blob_attr **tb)
 		char *ifname = blobmsg_get_string(cur);
 		s->master_ifindex = if_nametoindex(ifname);
 		s->flags |= DEV_OPT_MASTER;
+	}
+
+	if ((cur = tb[DEV_ATTR_EEE])) {
+		s->eee = blobmsg_get_bool(cur);
+		s->flags |= DEV_OPT_EEE;
 	}
 
 	cur = tb[DEV_ATTR_AUTH_VLAN];
@@ -1388,6 +1395,8 @@ device_dump_status(struct blob_buf *b, struct device *dev)
 			blobmsg_add_u8(b, "auth", st.auth);
 		if (st.flags & DEV_OPT_GRO)
 			blobmsg_add_u8(b, "gro", st.gro);
+		if (st.flags & DEV_OPT_EEE)
+			blobmsg_add_u8(b, "eee", st.eee);
 	}
 
 	s = blobmsg_open_table(b, "statistics");

--- a/device.h
+++ b/device.h
@@ -71,6 +71,7 @@ enum {
 	DEV_ATTR_AUTONEG,
 	DEV_ATTR_GRO,
 	DEV_ATTR_MASTER,
+	DEV_ATTR_EEE,
 	__DEV_ATTR_MAX,
 };
 
@@ -142,6 +143,7 @@ enum {
 	DEV_OPT_AUTONEG			= (1ULL << 36),
 	DEV_OPT_GRO			= (1ULL << 37),
 	DEV_OPT_MASTER			= (1ULL << 38),
+	DEV_OPT_EEE			= (1ULL << 39),
 };
 
 /* events broadcasted to all users of a device */
@@ -226,6 +228,7 @@ struct device_settings {
 	bool autoneg;
 	bool gro;
 	int master_ifindex;
+	bool eee;
 };
 
 struct device_vlan_range {


### PR DESCRIPTION
this commit adds support for configuring eee on a device via the network uci file. option eee is added to the config device section with type as boolean to enable or disable eee.