### PR TITLE
system-linux: switch to new ETHTOOL_xLINKSETTINGS API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,13 @@ IF (NOT DEFINED LIBNL_LIBS)
 	ENDIF()
 ENDIF()
 
+ADD_CUSTOM_COMMAND(
+	OUTPUT ethtool-modes.h
+	COMMAND ./make_ethtool_modes_h.sh ${CMAKE_C_COMPILER} > ./ethtool-modes.h
+	DEPENDS ./make_ethtool_modes_h.sh
+)
+ADD_CUSTOM_TARGET(ethtool-modes-h DEPENDS ethtool-modes.h)
+
 IF("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" AND NOT DUMMY_MODE)
 	SET(SOURCES ${SOURCES} system-linux.c)
 	SET(LIBS ${LIBS} ${LIBNL_LIBS})
@@ -72,3 +79,4 @@ TARGET_LINK_LIBRARIES(netifd ${LIBS})
 INSTALL(TARGETS netifd
 	RUNTIME DESTINATION sbin
 )
+ADD_DEPENDENCIES(netifd ethtool-modes-h)

--- a/device.c
+++ b/device.c
@@ -64,6 +64,11 @@ static const struct blobmsg_policy dev_attrs[__DEV_ATTR_MAX] = {
 	[DEV_ATTR_SPEED] = { .name = "speed", .type = BLOBMSG_TYPE_INT32 },
 	[DEV_ATTR_DUPLEX] = { .name = "duplex", .type = BLOBMSG_TYPE_BOOL },
 	[DEV_ATTR_VLAN] = { .name = "vlan", .type = BLOBMSG_TYPE_ARRAY },
+	[DEV_ATTR_PAUSE] = { .name = "pause", .type = BLOBMSG_TYPE_BOOL },
+	[DEV_ATTR_ASYM_PAUSE] = { .name = "asym_pause", .type = BLOBMSG_TYPE_BOOL },
+	[DEV_ATTR_RXPAUSE] = { .name = "rxpause", .type = BLOBMSG_TYPE_BOOL },
+	[DEV_ATTR_TXPAUSE] = { .name = "txpause", .type = BLOBMSG_TYPE_BOOL },
+	[DEV_ATTR_AUTONEG] = { .name = "autoneg", .type = BLOBMSG_TYPE_BOOL },
 };
 
 const struct uci_blob_param_list device_attr_list = {
@@ -281,6 +286,11 @@ device_merge_settings(struct device *dev, struct device_settings *n)
 	n->auth = s->flags & DEV_OPT_AUTH ? s->auth : os->auth;
 	n->speed = s->flags & DEV_OPT_SPEED ? s->speed : os->speed;
 	n->duplex = s->flags & DEV_OPT_DUPLEX ? s->duplex : os->duplex;
+	n->pause = s->flags & DEV_OPT_PAUSE ? s->pause : os->pause;
+	n->asym_pause = s->flags & DEV_OPT_ASYM_PAUSE ? s->asym_pause : os->asym_pause;
+	n->rxpause = s->flags & DEV_OPT_RXPAUSE ? s->rxpause : os->rxpause;
+	n->txpause = s->flags & DEV_OPT_TXPAUSE ? s->txpause : os->txpause;
+	n->autoneg = s->flags & DEV_OPT_AUTONEG ? s->autoneg : os->autoneg;
 	n->flags = s->flags | os->flags | os->valid_flags;
 }
 
@@ -504,6 +514,31 @@ device_init_settings(struct device *dev, struct blob_attr **tb)
 	if ((cur = tb[DEV_ATTR_DUPLEX])) {
 		s->duplex = blobmsg_get_bool(cur);
 		s->flags |= DEV_OPT_DUPLEX;
+	}
+
+	if ((cur = tb[DEV_ATTR_PAUSE])) {
+		s->pause = blobmsg_get_bool(cur);
+		s->flags |= DEV_OPT_PAUSE;
+	}
+
+	if ((cur = tb[DEV_ATTR_ASYM_PAUSE])) {
+		s->asym_pause = blobmsg_get_bool(cur);
+		s->flags |= DEV_OPT_ASYM_PAUSE;
+	}
+
+	if ((cur = tb[DEV_ATTR_RXPAUSE])) {
+		s->rxpause = blobmsg_get_bool(cur);
+		s->flags |= DEV_OPT_RXPAUSE;
+	}
+
+	if ((cur = tb[DEV_ATTR_TXPAUSE])) {
+		s->txpause = blobmsg_get_bool(cur);
+		s->flags |= DEV_OPT_TXPAUSE;
+	}
+
+	if ((cur = tb[DEV_ATTR_AUTONEG])) {
+		s->autoneg = blobmsg_get_bool(cur);
+		s->flags |= DEV_OPT_AUTONEG;
 	}
 	device_set_extra_vlans(dev, tb[DEV_ATTR_VLAN]);
 	device_set_disabled(dev, disabled);

--- a/device.h
+++ b/device.h
@@ -63,6 +63,11 @@ enum {
 	DEV_ATTR_SPEED,
 	DEV_ATTR_DUPLEX,
 	DEV_ATTR_VLAN,
+	DEV_ATTR_PAUSE,
+	DEV_ATTR_ASYM_PAUSE,
+	DEV_ATTR_RXPAUSE,
+	DEV_ATTR_TXPAUSE,
+	DEV_ATTR_AUTONEG,
 	__DEV_ATTR_MAX,
 };
 
@@ -127,6 +132,11 @@ enum {
 	DEV_OPT_ARP_ACCEPT		= (1ULL << 29),
 	DEV_OPT_SPEED			= (1ULL << 30),
 	DEV_OPT_DUPLEX			= (1ULL << 31),
+	DEV_OPT_PAUSE			= (1ULL << 32),
+	DEV_OPT_ASYM_PAUSE		= (1ULL << 33),
+	DEV_OPT_RXPAUSE			= (1ULL << 34),
+	DEV_OPT_TXPAUSE			= (1ULL << 35),
+	DEV_OPT_AUTONEG			= (1ULL << 36),
 };
 
 /* events broadcasted to all users of a device */
@@ -204,6 +214,11 @@ struct device_settings {
 	bool auth;
 	unsigned int speed;
 	bool duplex;
+	bool pause;
+	bool asym_pause;
+	bool rxpause;
+	bool txpause;
+	bool autoneg;
 };
 
 struct device_vlan_range {

--- a/make_ethtool_modes_h.sh
+++ b/make_ethtool_modes_h.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+CC="$1"
+[ -n "$TARGET_CC_NOCACHE" ] && CC="$TARGET_CC_NOCACHE"
+
+cat <<EOF
+#include <linux/ethtool.h>
+
+#define ETHTOOL_MODE_FULL(_speed, _mode) {					\\
+	.speed = (_speed),							\\
+	.bit_half = -1,								\\
+	.bit_full = ETHTOOL_LINK_MODE_ ## _speed ## base ## _mode ## _Full_BIT,	\\
+	.name = #_speed "base" #_mode,						\\
+}
+
+#define ETHTOOL_MODE_HALF(_speed, _mode) {					\\
+	.speed = (_speed),							\\
+	.bit_half = ETHTOOL_LINK_MODE_ ## _speed ## base ## _mode ## _Half_BIT,	\\
+	.bit_full = -1,								\\
+	.name = #_speed "base" #_mode,						\\
+}
+
+#define ETHTOOL_MODE_BOTH(_speed, _mode) {					\\
+	.speed = (_speed),							\\
+	.bit_half = ETHTOOL_LINK_MODE_ ## _speed ## base ## _mode ## _Half_BIT,	\\
+	.bit_full = ETHTOOL_LINK_MODE_ ## _speed ## base ## _mode ## _Full_BIT,	\\
+	.name = #_speed "base" #_mode,						\\
+}
+
+static const struct {
+	unsigned int speed;
+	int bit_half;
+	int bit_full;
+	const char *name;
+} ethtool_modes[] = {
+EOF
+
+echo "#include <linux/ethtool.h>" | "$CC" -E - | \
+	grep "ETHTOOL_LINK_MODE_[0-9]*base[A-Za-z0-9]*_...._BIT.*" | \
+	sed -r 's/.*ETHTOOL_LINK_MODE_([0-9]*)base([A-Za-z0-9]*)_(....)_BIT.*/\1 \2 \3/' | \
+	sort -u | LC_ALL=C sort -r -g | ( gothalf=0 ; while read speed mode duplex; do
+		if [ "$duplex" = "Half" ]; then
+			if [ "$gothalf" = "1" ]; then
+				echo -e "$speed \tETHTOOL_MODE_HALF($p_speed, $p_mode),"
+			fi
+			gothalf=1
+		elif [ "$duplex" = "Full" ]; then
+			if [ "$gothalf" = "1" ]; then
+				if [ "$p_speed" = "$speed" ] && [ "$p_mode" = "$mode" ]; then
+					echo -e "$speed \tETHTOOL_MODE_BOTH($speed, $mode),"
+				else
+					echo -e "$p_speed \tETHTOOL_MODE_HALF($p_speed, $p_mode),"
+					echo -e "$speed \tETHTOOL_MODE_FULL($speed, $mode),"
+				fi
+				gothalf=0
+			else
+				echo -e "$speed \tETHTOOL_MODE_FULL($speed, $mode),"
+			fi
+		else
+			continue
+		fi
+		p_speed="$speed"
+		p_mode="$mode"
+		p_duplex="$duplex"
+	done ; [ "$gothalf" = "1" ] && echo -e "$p_speed \tETHTOOL_MODE_HALF($p_speed, $p_mode)," ) | \
+	LC_ALL=C sort -g | cut -d' ' -f2-
+echo "};"


### PR DESCRIPTION
This work is based on https://github.com/openwrt/netifd/pull/2 and has been largely improved, completely dropping support for the legacy API.

`ETHTOOL_GSET` / `ETHTOOL_SSET` API is deprecated since Linux v5.2 released in 2016, see torvalds/linux@3f1ac7a700d03. All still maintained OpenWrt versions use kernel versions new enough to support the new API.

Hence migrate to `ETHTOOL_xLINKSETTINGS` API to handle auto-negotiation for flow-control as well as higher bandwidth like 2.5G, 5G, 10G, ...

Instead of hard-coding the supported modes, generate a header file during build describing them from `<linux/ethtool.h>`.
