### PR TITLE
config: network-device is incompatible with jshn

### DIFF
--- a/config.c
+++ b/config.c
@@ -732,8 +732,14 @@ config_init_board(void)
 	free(board_netdevs);
 	board_netdevs = NULL;
 
-	cur = config_find_blobmsg_attr(b.head, "network-device",
+	// a previous oversight resulted in network-device being used
+	// instead of network_device, to avoid breaking anything, try
+	// network_device first, fallback to network-device if nothing
+	// is found.
+	cur = config_find_blobmsg_attr(b.head, "network_device",
 				       BLOBMSG_TYPE_TABLE);
+	if (!cur) cur = config_find_blobmsg_attr(b.head, "network-device",
+		BLOBMSG_TYPE_TABLE);
 	if (!cur)
 		return;
 

--- a/config/board.json
+++ b/config/board.json
@@ -20,7 +20,7 @@
             "macaddr": "be:a5:11:16:76:d7"
         }
     },
-    "network-device": {
+    "network_device": {
         "eth0": {
             "macaddr": "bc:a5:11:16:76:d7"
         },


### PR DESCRIPTION
An oversight in openwrts uci-defaults.sh ucidef_set_network_device_* functions resulted in a hyphen (-) being used insted of a underscore (_) this causes problems for jshn which will translate the former to the latter. This causes config_init_board to return null on boards that set network?device using uci-defaults (or jshn).

This patch corrects the issue by defaulting to network_device with a fallback to network-device if nothing is returned.

Signed-off-by: Michael 'ASAP' Weinrich