### PR TITLE
system-linux: add option to configure DSA conduit device

### DIFF
--- a/config.c
+++ b/config.c
@@ -737,6 +737,24 @@ int config_get_default_gro(const char *ifname)
 	return blobmsg_get_bool(cur);
 }
 
+const char *config_get_default_conduit(const char *ifname)
+{
+	struct blob_attr *cur;
+
+	if (!board_netdevs)
+		return NULL;
+
+	cur = config_find_blobmsg_attr(board_netdevs, ifname, BLOBMSG_TYPE_TABLE);
+	if (!cur)
+		return NULL;
+
+	cur = config_find_blobmsg_attr(cur, "conduit", BLOBMSG_TYPE_STRING);
+	if (!cur)
+		return NULL;
+
+	return blobmsg_get_string(cur);
+}
+
 static void
 config_init_board(void)
 {

--- a/config.h
+++ b/config.h
@@ -22,5 +22,6 @@ extern bool config_init;
 int config_init_all(void);
 struct ether_addr *config_get_default_macaddr(const char *ifname);
 int config_get_default_gro(const char *ifname);
+const char *config_get_default_conduit(const char *ifname);
 
 #endif

--- a/device.h
+++ b/device.h
@@ -70,6 +70,7 @@ enum {
 	DEV_ATTR_TXPAUSE,
 	DEV_ATTR_AUTONEG,
 	DEV_ATTR_GRO,
+	DEV_ATTR_MASTER,
 	__DEV_ATTR_MAX,
 };
 
@@ -140,6 +141,7 @@ enum {
 	DEV_OPT_TXPAUSE			= (1ULL << 35),
 	DEV_OPT_AUTONEG			= (1ULL << 36),
 	DEV_OPT_GRO			= (1ULL << 37),
+	DEV_OPT_MASTER			= (1ULL << 38),
 };
 
 /* events broadcasted to all users of a device */
@@ -223,6 +225,7 @@ struct device_settings {
 	bool txpause;
 	bool autoneg;
 	bool gro;
+	int master_ifindex;
 };
 
 struct device_vlan_range {

--- a/system.h
+++ b/system.h
@@ -275,6 +275,7 @@ int system_if_resolve(struct device *dev);
 int system_if_dump_info(struct device *dev, struct blob_buf *b);
 int system_if_dump_stats(struct device *dev, struct blob_buf *b);
 struct device *system_if_get_parent(struct device *dev);
+int system_if_get_master_ifindex(struct device *dev);
 bool system_if_force_external(const char *ifname);
 void system_if_apply_settings(struct device *dev, struct device_settings *s,
 			      uint64_t apply_mask);


### PR DESCRIPTION
Device might have multiple CPU port with DSA based switch and OEM
firmware might set specific port to one CPU port (for example WAN) to
sustain full gigabit traffic with the kernel.

To set them iproute2 tool is currently required.
Add support to set the DSA port conduit directly from network config
using netlink. Example:

config device
            option name 'lan1'
            option conduit 'eth1'

Conduit option refer to the CPU port interface. Invalid option will
simply be ignored and won't be applied similar to what iproute2 does.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

---

I included changes from the GRO patch as they are required for the uci_blob_dirr.