### PR TITLE
netifd: fix undefined va_list value which can cause crashes

### DIFF
--- a/main.c
+++ b/main.c
@@ -126,6 +126,9 @@ netifd_log_message(int priority, const char *format, ...)
 
 	va_start(vl, format);
 	netifd_udebug_vprintf(format, vl);
+	va_end(vl);
+
+	va_start(vl, format);
 	if (use_syslog)
 		vsyslog(log_class[priority], format, vl);
 	else


### PR DESCRIPTION
Reinitialize the va_list value after the call
to netifd_udebug_vprintf() in netifd_log_message().

It's needed since netifd_udebug_vprintf() invokes vsnprintf() which in turn invokes the va_arg() macro, and after that call the va_list value is undefined.