### PR TITLE
device: add ubus event for link state change

### DIFF
--- a/device.c
+++ b/device.c
@@ -946,6 +946,7 @@ void device_set_link(struct device *dev, bool state)
 	if (!state)
 		dev->auth_status = false;
 	device_broadcast_event(dev, state ? DEV_EVENT_LINK_UP : DEV_EVENT_LINK_DOWN);
+	netifd_ubus_device_event(dev, state);
 }
 
 void device_set_ifindex(struct device *dev, int ifindex)

--- a/ubus.c
+++ b/ubus.c
@@ -1403,6 +1403,15 @@ netifd_ubus_interface_event(struct interface *iface, bool up)
 }
 
 void
+netifd_ubus_device_event(struct device *dev, bool state)
+{
+	blob_buf_init(&b, 0);
+	blobmsg_add_string(&b, "ifname", dev->ifname);
+	blobmsg_add_string(&b, "link", state? "up" : "down");
+	ubus_send_event(ubus_ctx, "network.device", b.head);
+}
+
+void
 netifd_ubus_interface_notify(struct interface *iface, bool up)
 {
 	const char *event = (up) ? "interface.update" : "interface.down";

--- a/ubus.h
+++ b/ubus.h
@@ -26,5 +26,6 @@ void netifd_ubus_remove_interface(struct interface *iface);
 void netifd_ubus_interface_event(struct interface *iface, bool up);
 void netifd_ubus_interface_notify(struct interface *iface, bool up);
 void netifd_ubus_device_notify(const char *event, struct blob_attr *data, int timeout);
+void netifd_ubus_device_event(struct device *dev, bool state);
 
 #endif


### PR DESCRIPTION
Add a ubus event network.device for link state change to generate an event when the link goes up and down.

The event looks as follows:
{ "network.device": {"ifname":"eth3","link":"down"} }