### PR TITLE
system-linux: re-apply ethtool on phy attachment

### DIFF
--- a/system-linux.c
+++ b/system-linux.c
@@ -702,6 +702,9 @@ static int system_get_arp_accept(struct device *dev, char *buf, const size_t buf
 #endif
 
 static void
+system_set_ethtool_settings(struct device *dev, struct device_settings *s);
+
+static void
 system_device_update_state(struct device *dev, unsigned int flags, unsigned int ifindex)
 {
 	if (dev->type == &simple_device_type) {
@@ -711,6 +714,9 @@ system_device_update_state(struct device *dev, unsigned int flags, unsigned int 
 		device_set_present(dev, ifindex > 0);
 	}
 	device_set_link(dev, flags & IFF_LOWER_UP ? true : false);
+
+	if ((flags & IFF_UP) && !(flags & IFF_LOWER_UP))
+		system_set_ethtool_settings(dev, &dev->settings);
 }
 
 /* Evaluate netlink messages */


### PR DESCRIPTION
ethtool settings applied before the interface is in IFF_UP state are going to be lost when phylink is being used.
This is the case with many modern NICs as well as when using SFP modules, resulting in the speed, duplex, *pause and autoneg settings not having any effect.

Reapply ethtool settings once the PHY is attached.