### PR TITLE
system-linux: Set `ignore-df` flag on GRE tunnels

### DIFF
--- a/system-linux.c
+++ b/system-linux.c
@@ -4583,6 +4583,7 @@ static int system_add_gre_tunnel(const char *name, const char *kind,
 			ttl = 64;
 
 		nla_put_u8(nlm, IFLA_GRE_PMTUDISC, set_df ? 1 : 0);
+		nla_put_u8(nlm, IFLA_GRE_IGNORE_DF, set_df ? 0 : 1);
 
 		nla_put_u8(nlm, IFLA_GRE_TOS, tos);
 	}


### PR DESCRIPTION
This is required to make `gretap` fragment packets according to https://bugzilla.kernel.org/show_bug.cgi?id=14837