### PR TITLE
iprule: add ipproto property

### DIFF
--- a/iprule.c
+++ b/iprule.c
@@ -45,6 +45,7 @@ enum {
 	RULE_GOTO,
 	RULE_SUP_PREFIXLEN,
 	RULE_UIDRANGE,
+	RULE_IPPROTO,
 	RULE_DISABLED,
 	__RULE_MAX
 };
@@ -63,6 +64,7 @@ static const struct blobmsg_policy rule_attr[__RULE_MAX] = {
 	[RULE_UIDRANGE] = { .name = "uidrange", .type = BLOBMSG_TYPE_STRING },
 	[RULE_ACTION] = { .name = "action", .type = BLOBMSG_TYPE_STRING },
 	[RULE_GOTO]   = { .name = "goto", .type = BLOBMSG_TYPE_INT32 },
+	[RULE_IPPROTO]  = { .name = "ipproto", .type = BLOBMSG_TYPE_INT32 },
 	[RULE_DISABLED] = { .name = "disabled", .type = BLOBMSG_TYPE_BOOL },
 };
 
@@ -307,6 +309,14 @@ iprule_add(struct blob_attr *attr, bool v6)
 	if ((cur = tb[RULE_GOTO]) != NULL) {
 		rule->gotoid = blobmsg_get_u32(cur);
 		rule->flags |= IPRULE_GOTO;
+	}
+
+	if ((cur = tb[RULE_IPPROTO]) != NULL) {
+		if ((rule->ipproto = blobmsg_get_u32(cur)) > 255) {
+			D(INTERFACE, "Invalid ipproto value: %u", blobmsg_get_u32(cur));
+			goto error;
+		}
+		rule->flags |= IPRULE_IPPROTO;
 	}
 
 	vlist_add(&iprules, &rule->node, rule);

--- a/iprule.h
+++ b/iprule.h
@@ -66,6 +66,9 @@ enum iprule_flags {
 
 	/* rule specifies uidrange */
 	IPRULE_UIDRANGE		= (1 << 14),
+
+	/* rule specifies ipproto */
+	IPRULE_IPPROTO  = (1 << 15),
 };
 
 struct iprule {
@@ -109,6 +112,7 @@ struct iprule {
 	unsigned int uidrange_end;
 	unsigned int action;
 	unsigned int gotoid;
+	unsigned int ipproto;
 };
 
 extern struct vlist_tree iprules;

--- a/system-linux.c
+++ b/system-linux.c
@@ -3571,6 +3571,9 @@ static int system_iprule(struct iprule *rule, int cmd)
 	if (rule->flags & IPRULE_GOTO)
 		nla_put_u32(msg, FRA_GOTO, rule->gotoid);
 
+	if (rule->flags & IPRULE_IPPROTO)
+		nla_put_u32(msg, FRA_IP_PROTO, rule->ipproto);
+
 	return system_rtnl_call(msg);
 }
 


### PR DESCRIPTION
```
config rule
	option ...
	option ipproto '17'
```

This allows handling rules which anchor to protocol number like:

`ip ru add from all ipproto udp table udp_table prior 10`

Handle ipproto as an unsigned integer.

https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml

Tested on 23.05.5 x86_64