### PR TITLE
Restore disable_ipv6 sysctl after removing a device from bridge or bond

### DIFF
--- a/bonding.c
+++ b/bonding.c
@@ -171,6 +171,11 @@ bonding_disable_port(struct bonding_port *bp, bool keep_dev)
 	if (!keep_dev)
 		device_release(&bp->dev);
 
+	if (bp->dev.dev->settings.flags & DEV_OPT_IPV6) {
+		bp->dev.dev->settings.ipv6 = 1;
+		bp->dev.dev->settings.flags &= ~DEV_OPT_IPV6;
+	}
+
 	return 0;
 }
 

--- a/bridge.c
+++ b/bridge.c
@@ -327,6 +327,11 @@ bridge_disable_member(struct bridge_member *bm, bool keep_dev)
 	if (!keep_dev)
 		device_release(&bm->dev);
 
+	if (bm->dev.dev->settings.flags & DEV_OPT_IPV6) {
+		bm->dev.dev->settings.ipv6 = 1;
+		bm->dev.dev->settings.flags &= ~DEV_OPT_IPV6;
+	}
+
 	device_broadcast_event(&bst->dev, DEV_EVENT_TOPO_CHANGE);
 
 	return 0;


### PR DESCRIPTION
If a device is added to a bond or bridge, the disable_ipv6 sysctl is set, so that no link local addresses are present on the slave devices.

However, the disable_ipv6 sysctl is not restored after removing the device from the bridge or bond. Therefore, no IPv6 link local addresses are added and autoconfiguration does not work.

Set the disable_ipv6 to '0' on device removal from bridge or bond.