### PR TITLE
iprule: amend ipproto netlink nla_put_u32 to nla_put_u8

### DIFF
--- a/system-linux.c
+++ b/system-linux.c
@@ -3578,7 +3578,7 @@ static int system_iprule(struct iprule *rule, int cmd)
 		nla_put_u32(msg, FRA_GOTO, rule->gotoid);
 
 	if (rule->flags & IPRULE_IPPROTO)
-		nla_put_u32(msg, FRA_IP_PROTO, rule->ipproto);
+		nla_put_u8(msg, FRA_IP_PROTO, rule->ipproto);
 
 	return system_rtnl_call(msg);
 }


### PR DESCRIPTION
FRA_IP_PROTO expects an 8 bit value.

Follow-up fix for d29cf707478cfc5465fc8a7b8ccfde72a739a4f6.

uint8 prevents the kernel log message:
`netlink: 'netifd': attribute type 22 has an invalid length.`

The message is otherwise harmless; ip rules using ipproto are created successfully.

Tested on 24.10-snapshot

ping @nbd168 - sorry for the noise.