### PR TITLE
iprule: resolve ipproto by name

### DIFF
--- a/iprule.c
+++ b/iprule.c
@@ -64,7 +64,7 @@ static const struct blobmsg_policy rule_attr[__RULE_MAX] = {
 	[RULE_UIDRANGE] = { .name = "uidrange", .type = BLOBMSG_TYPE_STRING },
 	[RULE_ACTION] = { .name = "action", .type = BLOBMSG_TYPE_STRING },
 	[RULE_GOTO]   = { .name = "goto", .type = BLOBMSG_TYPE_INT32 },
-	[RULE_IPPROTO]  = { .name = "ipproto", .type = BLOBMSG_TYPE_INT32 },
+	[RULE_IPPROTO]  = { .name = "ipproto", .type = BLOBMSG_TYPE_STRING },
 	[RULE_DISABLED] = { .name = "disabled", .type = BLOBMSG_TYPE_BOOL },
 };
 
@@ -312,8 +312,8 @@ iprule_add(struct blob_attr *attr, bool v6)
 	}
 
 	if ((cur = tb[RULE_IPPROTO]) != NULL) {
-		if ((rule->ipproto = blobmsg_get_u32(cur)) > 255) {
-			D(INTERFACE, "Invalid ipproto value: %u", blobmsg_get_u32(cur));
+		if (!system_resolve_iprule_ipproto(blobmsg_data(cur), &rule->ipproto)) {
+			D(INTERFACE, "Failed to parse rule ip protocol: %s", (char *) blobmsg_data(cur));
 			goto error;
 		}
 		rule->flags |= IPRULE_IPPROTO;

--- a/system-dummy.c
+++ b/system-dummy.c
@@ -323,6 +323,12 @@ int system_flush_iprules(void)
 	return 0;
 }
 
+bool system_resolve_iprule_ipproto(const char *name, unsigned int *id)
+{
+	*id = 0;
+	return true;
+}
+
 bool system_resolve_iprule_action(const char *action, unsigned int *id)
 {
 	*id = 0;

--- a/system-linux.c
+++ b/system-linux.c
@@ -27,6 +27,7 @@
 #include <net/if_arp.h>
 
 #include <limits.h>
+#include <netdb.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/ether.h>
@@ -3744,6 +3745,27 @@ int system_flush_iprules(void)
 bool system_resolve_iprule_action(const char *action, unsigned int *id)
 {
 	return system_rtn_aton(action, id);
+}
+
+bool system_resolve_iprule_ipproto(const char *name, unsigned int *id)
+{
+	char *e;
+	struct protoent *ent;
+	unsigned int n, ipproto = 0;
+
+	if ((n = strtoul(name, &e, 0)) > 0 && *e == '\0')
+		ipproto = n;
+	else {
+		ent = getprotobyname(name);
+
+		if (ent)
+			ipproto = ent->p_proto;
+		else
+			return false;
+	}
+
+	*id = ipproto;
+	return true;
 }
 
 time_t system_get_rtime(void)

--- a/system.h
+++ b/system.h
@@ -311,6 +311,7 @@ int system_add_iprule(struct iprule *rule);
 int system_del_iprule(struct iprule *rule);
 int system_flush_iprules(void);
 
+bool system_resolve_iprule_ipproto(const char *name, unsigned int *id);
 bool system_resolve_iprule_action(const char *action, unsigned int *id);
 
 time_t system_get_rtime(void);


### PR DESCRIPTION
Handle ipproto as an string. Set protocol in lowercase for musl libc compatibility.