### PR TITLE
Fix/bonding primary selection

### DIFF
--- a/system-linux.c
+++ b/system-linux.c
@@ -1189,7 +1189,7 @@ int system_bonding_set_device(struct device *dev, struct bonding_config *cfg)
 
 	system_set_dev_sysfs("bonding/mode", ifname, bonding_policy_str[cfg->policy]);
 
-	system_set_dev_sysfs_int("bonding/all_ports_active", ifname, cfg->all_ports_active);
+	system_set_dev_sysfs_int("bonding/all_slaves_active", ifname, cfg->all_ports_active);
 
 	if (cfg->policy == BONDING_MODE_BALANCE_XOR ||
 	    cfg->policy == BONDING_MODE_BALANCE_TLB ||


### PR DESCRIPTION
In Luci bug [#7683](https://github.com/openwrt/luci/issues/7683) we have identified that netifd is not picking up the configured primary interface.
This patch solves the issue discussed in that ticket.

This patch might also fix reported issue #48 but its unclear to me how the flag was forced.
right now netifd is writing to a file that does not exist.

The patch has been tested on VM x86-64 enviroment.

@nbd168 I've co-authored you due to the patch you sent dor the dynamic "reload".
If you think it is necessary please pick the patch up and add the signoff before merge.