### PR TITLE
bridge: reset primary on adding device to empty bridge

### DIFF
--- a/bridge.c
+++ b/bridge.c
@@ -778,13 +778,16 @@ bridge_member_cb(struct device_user *dep, enum device_event ev)
 		if (bridge_enable_member(bm))
 			break;
 
+		if (ev == DEV_EVENT_ADD && nst->n_present == 1) {
+			bridge_reset_primary(bst);
+		}
 		/*
 		 * Adding a bridge member can overwrite the bridge mtu
 		 * in the kernel, apply the bridge settings in case the
 		 * bridge mtu is set
 		 */
 		system_if_apply_settings(&bst->dev, &bst->dev.settings,
-					 DEV_OPT_MTU | DEV_OPT_MTU6);
+					 DEV_OPT_MTU | DEV_OPT_MTU6 | DEV_OPT_MACADDR);
 		break;
 	case DEV_EVENT_LINK_UP:
 		if (!bst->has_vlans)


### PR DESCRIPTION
This means that when only wireless devices are on a bridge, set the MAC to something predictable (otherwise a random MAC is used which differs on each bring-up).

This seems to work as I would expect. However, I'm not familiar with netifd internals so I've probably missed something, and there may be a connected issue where if you remove so that the bridge is empty then add it will consider the MAC address already set and will refuse to reset_primary (see bridge_reset_primary). I haven't tried to change this, as it looks like it would require additional state.