### PR TITLE
interface-ip: install routes after IPv6 prefix address setup

### DIFF
--- a/interface-ip.c
+++ b/interface-ip.c
@@ -1727,12 +1727,6 @@ void interface_ip_set_enabled(struct interface_ip_settings *ip, bool enabled)
 		addr->enabled = enabled;
 	}
 
-	vlist_for_each_element(&ip->route, route, node)
-		interface_ip_set_route_enabled(ip, route, enabled);
-	if (ip == &iface->proto_ip)
-		vlist_for_each_element(&iface->host_routes, route, node)
-			interface_ip_set_route_enabled(ip, route, enabled);
-
 	vlist_for_each_element(&ip->neighbor, neighbor, node) {
 		if (neighbor->enabled == enabled)
 			continue;
@@ -1752,6 +1746,12 @@ void interface_ip_set_enabled(struct interface_ip_settings *ip, bool enabled)
 		list_for_each_entry(a, &c->assignments, head)
 			if (!strcmp(a->name, ip->iface->name))
 				interface_set_prefix_address(a, c, ip->iface, enabled);
+
+	vlist_for_each_element(&ip->route, route, node)
+		interface_ip_set_route_enabled(ip, route, enabled);
+	if (ip == &iface->proto_ip)
+		vlist_for_each_element(&iface->host_routes, route, node)
+			interface_ip_set_route_enabled(ip, route, enabled);
 
 	if (ip->iface->policy_rules_set != enabled &&
 	    ip->iface->l3_dev.dev) {


### PR DESCRIPTION
In `interface_ip_set_enabled()`, routes are currently installed after IP addresses are set up, but before IPv6 prefix addresses are set up.  This prevents configured static IPv6 routes that have next hops set to addresses belonging to those prefixes from being installed during interface setup as the relevant netlink requests return `-EHOSTUNREACH` (No route to host).  Fix by deferring route installation until after IPv6 prefix addresses are configured.

---

This PR should help with openwrt/openwrt#5089, but it does not solve the problem completely for all types of IPv6 routes defined via `config route6` in `/etc/config/network`.  It boils down to when the IPv6 prefix of the route's next hop gets configured.

Let's assume we want to route an arbitrary IPv6 subnet via an IPv6 next hop located on the LAN side.  Now:

 1. With the code currently present in netifd's `master` branch, AFAICT, virtually no static IPv6 routes configured via `/etc/config/network` will be installed properly.

 2. With the change proposed in this PR applied, static IPv6 routes whose next hops are in (statically defined) ULA prefixes should be installed correctly; that's because netifd will be able to configure the ULA-sourced IPv6 address on a given interface before attempting to install any IPv6 routes, preventing "No route to host" errors.

 3. With the change proposed in this PR applied, static IPv6 routes whose next hops are in prefixes that are assigned dynamically (e.g. when prefix setup is only triggered after `wan6` goes up) will still not be installed properly.

The problem with this last scenario is that when the LAN interface goes up and netifd attempts to install the static IPv6 route, it still doesn't know what IPv6 prefix to assign addresses from on the LAN side (because the WAN side may not yet be up).  I currently have to work around this by dropping a hotplug script into `/etc/hotplug.d/iface/`, e.g.:

    [ "${ACTION}" = "ifup" ] && [ "${INTERFACE}" = "wan6" ] && {
    	ip -6 route add <prefix> via <next-hop>
    }

I guess the core issue here is that this route should be installed "for the LAN interface" after *another* interface gets its IPv6 addressing set up.  Sadly, I don't know enough about the inner workings of netifd to propose a proper solution for that scenario.
