### PR TITLE
system-linux: add support for configurable rxhash option

### DIFF
--- a/device.c
+++ b/device.c
@@ -76,6 +76,7 @@ static const struct blobmsg_policy dev_attrs[__DEV_ATTR_MAX] = {
 	[DEV_ATTR_MASTER] = { .name = "conduit", .type = BLOBMSG_TYPE_STRING },
 	[DEV_ATTR_EEE] = { .name = "eee", .type = BLOBMSG_TYPE_BOOL },
 	[DEV_ATTR_TAGS] = { .name = "tags", .type = BLOBMSG_TYPE_ARRAY },
+	[DEV_ATTR_RXHASH] = { .name = "rxhash", .type = BLOBMSG_TYPE_BOOL },
 };
 
 const struct uci_blob_param_list device_attr_list = {
@@ -310,6 +311,7 @@ device_merge_settings(struct device *dev, struct device_settings *n)
 	n->gro = s->flags & DEV_OPT_GRO ? s->gro : os->gro;
 	n->eee = s->flags & DEV_OPT_EEE ? s->eee : os->eee;
 	n->master_ifindex = s->flags & DEV_OPT_MASTER ? s->master_ifindex : os->master_ifindex;
+	n->rxhash = s->flags & DEV_OPT_RXHASH ? s->rxhash : os->rxhash;
 	n->flags = s->flags | os->flags | os->valid_flags;
 }
 
@@ -577,6 +579,11 @@ device_init_settings(struct device *dev, struct blob_attr **tb)
 	if ((cur = tb[DEV_ATTR_EEE])) {
 		s->eee = blobmsg_get_bool(cur);
 		s->flags |= DEV_OPT_EEE;
+	}
+
+	if ((cur = tb[DEV_ATTR_RXHASH])) {
+		s->rxhash = blobmsg_get_bool(cur);
+		s->flags |= DEV_OPT_RXHASH;
 	}
 
 	/* Remember the settings present in UCI */
@@ -1437,6 +1444,8 @@ device_dump_status(struct blob_buf *b, struct device *dev)
 			blobmsg_add_u8(b, "gro", st.gro);
 		if (st.flags & DEV_OPT_EEE)
 			blobmsg_add_u8(b, "eee", st.eee);
+		if (st.flags & DEV_OPT_RXHASH)
+			blobmsg_add_u8(b, "rxhash", st.rxhash);
 	}
 
 	s = blobmsg_open_table(b, "statistics");

--- a/device.h
+++ b/device.h
@@ -73,6 +73,7 @@ enum {
 	DEV_ATTR_MASTER,
 	DEV_ATTR_EEE,
 	DEV_ATTR_TAGS,
+	DEV_ATTR_RXHASH,
 	__DEV_ATTR_MAX,
 };
 
@@ -145,6 +146,7 @@ enum {
 	DEV_OPT_GRO			= (1ULL << 37),
 	DEV_OPT_MASTER			= (1ULL << 38),
 	DEV_OPT_EEE			= (1ULL << 39),
+	DEV_OPT_RXHASH			= (1ULL << 40),
 };
 
 /* events broadcasted to all users of a device */
@@ -230,6 +232,7 @@ struct device_settings {
 	bool gro;
 	int master_ifindex;
 	bool eee;
+	bool rxhash;
 };
 
 struct device_vlan_range {


### PR DESCRIPTION
This series extends `netifd` with helper functions for ethtool
feature management and introduces a new `rxhash` device option.

Changes include:

* Refactor  `ethtool_feature_value()` to `ethtool_get_feature_value()`
  to query NIC features with error handling (-1 on error, 0/1 for disabled/enabled).
* Add `ethtool_set_feature_value()` to enable or disable NIC features
  via `ETHTOOL_SFEATURES`.
* Introduce `rxhash` option in network configuration to toggle
  Receive Side Scaling (RSS). This is useful on devices such as
  Marvell boards, where RSS support exists but isn't enabled by default.

Example configuration:

    config device
        option name 'eth0'
        option rxhash '1'