### PR TITLE
bridge: fix extra_vlan memory leak

### DIFF
--- a/bridge.c
+++ b/bridge.c
@@ -726,6 +726,7 @@ restart:
 		device_set_present(dev, true);
 	}
 
+	free(bm->extra_vlan);
 	free(bm);
 }
 


### PR DESCRIPTION
Minor memory leak.

Memory is sometimes allocated here: https://github.com/openwrt/netifd/blob/2a85440bcd82caf66b29428145affb30388a4994/bridge.c#L463