### PR TITLE
device: skip VLAN chain lookup for existing kernel interfaces

### DIFF
--- a/device.c
+++ b/device.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <net/if.h>
 #include <assert.h>
 
 #include <sys/types.h>
@@ -893,8 +894,16 @@ __device_get(const char *name, int create, bool check_vlan)
 
 	dev = avl_find_element(&devices, name, dev, avl);
 
-	if (!dev && check_vlan && strchr(name, '.'))
-		return get_vlan_device_chain(name, create);
+	if (!dev && check_vlan && strchr(name, '.')) {
+		/*
+		 * Only treat dotted names as VLAN-style if the full name does
+		 * NOT already exist as a real kernel netdev.  Externally managed
+		 * interfaces (e.g. ModemManager QMI mux links: qmapmux0.0) are
+		 * valid kernel devices whose names happen to contain a dot.
+		 */
+		if (!if_nametoindex(name))
+			return get_vlan_device_chain(name, create);
+	}
 
 	if (name[0] == '@')
 		return device_alias_get(name + 1);


### PR DESCRIPTION
netifd's __device_get() treats any interface name containing a '.' as a
VLAN-style device by immediately dispatching to get_vlan_device_chain().

Modern externally-managed interfaces such as the rmnet mux links created
by ModemManager for QMI QMAP multiplexing (e.g. qmapmux0.0, qmapmux0.1)
are legitimate kernel netdevices that happen to contain a dot.  When
ModemManager calls notify_proto with such an ifname, netifd incorrectly
tries to resolve it as a VLAN device:

  ubus call network.device status '{"name":"qmapmux0.0"}'
  => { "type": "VLAN", "present": false }

This causes notify_proto to fail with "Unknown error" and the interface
never comes up under netifd control.

Fix: before dispatching to get_vlan_device_chain(), probe the kernel with
if_nametoindex().  If the full dotted name already exists as a real netdev,
skip the VLAN path and fall through to the normal device lookup / creation
path.  This preserves all existing VLAN behaviour: when eth0.10 does not
yet exist in the kernel, if_nametoindex("eth0.10") returns 0 and netifd
still creates it as a VLAN device as before.