### PR TITLE
Enhance VLAN device retrieval with parent check

### DIFF
--- a/device.c
+++ b/device.c
@@ -890,11 +890,19 @@ struct device *
 __device_get(const char *name, int create, bool check_vlan)
 {
 	struct device *dev;
+	const char *dot;
 
 	dev = avl_find_element(&devices, name, dev, avl);
 
-	if (!dev && check_vlan && strchr(name, '.'))
-		return get_vlan_device_chain(name, create);
+	if (!dev && check_vlan && (dot = strchr(name, '.')))
+	{
+		char parent[IFNAMSIZ];
+		int len = dot - name;
+		memcpy(parent, name, len);
+		parent[len] = '\0';
+		if (if_nametoindex(parent))
+			return get_vlan_device_chain(name, create);
+	}
 
 	if (name[0] == '@')
 		return device_alias_get(name + 1);


### PR DESCRIPTION
Enhance VLAN device retrieval to check parent device existence before fetching VLAN chain. This is useful when ModemManager creates rmnet interfaces on top of pci_generic mhi interfaces with a different name like "qmapmux0.0@mhi_hwip0".