### PR TITLE
ethtool: avoid unneeded ioctl

### DIFF
--- a/system-linux.c
+++ b/system-linux.c
@@ -2448,6 +2448,10 @@ system_set_ethtool_settings(struct device *dev, struct device_settings *s)
 	if (s->flags & (DEV_OPT_PSE | DEV_OPT_PSE_PODL | DEV_OPT_PSE_POWER_LIMIT | DEV_OPT_PSE_PRIORITY))
 		system_pse_set(dev, s);
 
+	/* Avoid a rmw ioctl call if nothing needs to be changed. */
+	if (!(s->flags & (DEV_OPT_AUTONEG | DEV_OPT_SPEED | DEV_OPT_DUPLEX | DEV_OPT_PAUSE | DEV_OPT_ASYM_PAUSE)))
+		return;
+
 	memset(&ecmd, 0, sizeof(ecmd));
 	ecmd.req.cmd = ETHTOOL_GLINKSETTINGS;
 	strncpy(ifr.ifr_name, dev->ifname, sizeof(ifr.ifr_name) - 1);


### PR DESCRIPTION
system_set_ethtool_settings() might be called if the interface is still in admin state. In this status the kernel does not guarantee a consistent result of phylink_ethtool_ksettings_get(). E.g. the autonegotiation flag is always false for a SFP module that is plugged in during boot.

To avoid a inconsistented read/modify/write sequence return early from system_set_ethtool_settings() if nothing needs to be done.