### PR TITLE
interface: retry extdev claim on ifindex update

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -450,6 +450,20 @@ interface_main_dev_cb(struct device_user *dep, enum device_event ev)
 	case DEV_EVENT_DOWN:
 		interface_set_enabled(iface, false);
 		break;
+	case DEV_EVENT_UPDATE_IFINDEX:
+		/*
+		 * External devices can briefly exist without a resolvable
+		 * ifindex. If an autostart interface tried to claim such a
+		 * device, retry setup once the ifindex becomes available.
+		 */
+		if (iface->autostart &&
+		    iface->state == IFS_DOWN &&
+		    iface->available &&
+		    dep->dev &&
+		    dep->dev->external &&
+		    dep->dev->ifindex)
+			interface_set_up(iface);
+		break;
 	case DEV_EVENT_AUTH_UP:
 	case DEV_EVENT_LINK_UP:
 	case DEV_EVENT_LINK_DOWN:
@@ -1151,7 +1165,8 @@ interface_set_up(struct interface *iface)
 			ret = device_claim(&iface->main_dev);
 			if (!ret)
 				interface_check_state(iface);
-			else
+			else if (!(iface->main_dev.dev->external &&
+				   !iface->main_dev.dev->ifindex))
 				error = "DEVICE_CLAIM_FAILED";
 		} else {
 			ret = __interface_set_up(iface);


### PR DESCRIPTION
## Summary

Retry autostart setup for external devices once a valid ifindex
appears, and avoid treating the transient external/no-ifindex
claim failure as terminal.

## Problem

External devices can briefly exist without a resolvable ifindex.
If an autostart interface tries to claim such a device, netifd
can report DEVICE_CLAIM_FAILED and leave the interface down even
after the device later receives a valid ifindex.

## Fix

- suppress terminal DEVICE_CLAIM_FAILED for the transient
  external-device/no-ifindex case
- retry interface setup on DEV_EVENT_UPDATE_IFINDEX

## Notes

This keeps genuine claim failures unchanged while fixing
recreated external devices such as tunnel interfaces.
