### PR TITLE
vrf: add fixes and sync changes with bonding.c/bridge.c

### DIFF
--- a/system-linux.c
+++ b/system-linux.c
@@ -1181,19 +1181,21 @@ system_vrf_if(int vrf_index, struct device *dev)
 int system_vrf_addif(struct device *vrf, struct device *dev)
 {
 	char *oldvrf;
-	int tries = 0;
+	int tries;
 	int ret;
 
-retry:
-	ret = 0;
-	oldvrf = system_get_vrf(dev->ifname, dev_buf, sizeof(dev_buf));
-	if (!oldvrf || strcmp(oldvrf, vrf->ifname) != 0) {
+	for (tries = 0; tries < 3; tries++) {
+		ret = 0;
+		oldvrf = system_get_vrf(dev->ifname, dev_buf, sizeof(dev_buf));
+		if (oldvrf && !strcmp(oldvrf, vrf->ifname))
+			break;
+
 		ret = system_vrf_if(vrf->ifindex, dev);
-		tries++;
+		if (!ret)
+			break;
+
 		D(SYSTEM, "Failed to add device '%s' to vrf '%s' (tries=%d): %s\n",
 		  dev->ifname, vrf->ifname, tries, strerror(errno));
-		if (tries <= 3)
-			goto retry;
 	}
 
 	return ret;

--- a/vrf.c
+++ b/vrf.c
@@ -167,12 +167,6 @@ vrf_enable_member(struct vrf_member *vm)
 	if (ret)
 		goto error;
 
-	/* Disable IPv6 for vrf ports */
-	if (!(vm->dev.dev->settings.flags & DEV_OPT_IPV6)) {
-		vm->dev.dev->settings.ipv6 = 0;
-		vm->dev.dev->settings.flags |= DEV_OPT_IPV6;
-	}
-
 	ret = device_claim(&vm->dev);
 	if (ret < 0)
 		goto error;

--- a/vrf.c
+++ b/vrf.c
@@ -1,3 +1,18 @@
+/*
+ * netifd - network interface daemon
+ * Copyright (C) 2025 Felix Fietkau <nbd@nbd.name>
+ * Copyright (C) 2026 Maxim Anisimov <maxim.anisimov.ua@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/vrf.c
+++ b/vrf.c
@@ -186,7 +186,7 @@ vrf_enable_member(struct vrf_member *vm)
 
 	ret = system_vrf_addif(&vst->dev, vm->dev.dev);
 	if (ret < 0) {
-		D(DEVICE, "Vrf device %s could not be added\n", vm->dev.dev->ifname);
+		D(DEVICE, "Vrf device %s could not be added", vm->dev.dev->ifname);
 		goto error;
 	}
 
@@ -213,7 +213,7 @@ vrf_remove_member(struct vrf_member *vm)
 	if (!vm->present)
 		return;
 
-	if (vst->dev.active)
+	if (vst->active)
 		vrf_disable_member(vm, false);
 
 	vm->present = false;
@@ -245,7 +245,7 @@ vrf_free_member(struct vrf_member *vm)
 	 * Ensure that claiming the device is retried by toggling its present
 	 * state
 	 */
-	if (dev->present) {
+	if (dev->present && !dev->active) {
 		device_set_present(dev, false);
 		device_set_present(dev, true);
 	}
@@ -320,6 +320,7 @@ vrf_set_down(struct vrf_state *vst)
 {
 	struct vrf_member *vm;
 
+	uloop_timeout_cancel(&vst->retry);
 	vst->set_state(&vst->dev, false);
 
 	vlist_for_each_element(&vst->members, vm, node)
@@ -501,7 +502,11 @@ vrf_free(struct device *dev)
 	struct vrf_state *vst;
 
 	vst = container_of(dev, struct vrf_state, dev);
+	uloop_timeout_cancel(&vst->retry);
 	vlist_flush_all(&vst->members);
+
+	system_vrf_delvrf(dev);
+
 	free(vst->config_data);
 	free(vst);
 }
@@ -573,7 +578,7 @@ vrf_reload(struct device *dev, struct blob_attr *attr,
 	struct blob_attr *tb_v[__VRF_ATTR_MAX];
 	enum dev_change_type ret = DEV_CONFIG_APPLIED;
 	struct vrf_state *vst;
-	unsigned long diff[2];
+	unsigned long diff[2] = {};
 
 	BUILD_BUG_ON(sizeof(diff) < __VRF_ATTR_MAX / BITS_PER_LONG);
 
@@ -594,11 +599,10 @@ vrf_reload(struct device *dev, struct blob_attr *attr,
 		blobmsg_parse_attr(vrf_attrs, __VRF_ATTR_MAX, otb_v,
 				   vst->config_data);
 
-		diff[0] = diff[1] = 0;
 		uci_blob_diff(tb_v, otb_v, &vrf_attr_list, diff);
 		if (diff[0] & ~(1 << VRF_ATTR_PORTS)) {
 			ret = DEV_CONFIG_RESTART;
-			D(DEVICE, "Vrf %s attributes have changed, diff=[%lx %lx]\n",
+			D(DEVICE, "Vrf %s attributes have changed, diff=[%lx %lx]",
 			  dev->ifname, diff[1], diff[0]);
 		}
 

--- a/vrf.c
+++ b/vrf.c
@@ -40,7 +40,7 @@ static enum dev_change_type
 vrf_reload(struct device *dev, struct blob_attr *attr,
 	   struct blob_attr **tb_dev);
 
-static struct device_type vrf_state_type = {
+static struct device_type vrf_device_type = {
 	.name = "vrf",
 	.config_params = &vrf_attr_list,
 
@@ -413,7 +413,6 @@ vrf_member_update(struct vlist_tree *tree, struct vlist_node *node_new,
 		device_add_user(&vm->dev, dev);
 	}
 
-
 	if (node_old) {
 		vm = container_of(node_old, struct vrf_member, node);
 		vrf_free_member(vm);
@@ -651,7 +650,7 @@ vrf_create(const char *name, struct device_type *devtype,
 	return dev;
 }
 
-static void __init vrf_state_type_init(void)
+static void __init vrf_device_type_init(void)
 {
-	device_type_add(&vrf_state_type);
+	device_type_add(&vrf_device_type);
 }

--- a/vrf.c
+++ b/vrf.c
@@ -59,7 +59,6 @@ struct vrf_state {
 
 	struct blob_attr *config_data;
 	unsigned int table;
-	bool vrf_empty;
 	struct blob_attr *ports;
 	bool active;
 	bool force_active;
@@ -215,13 +214,6 @@ vrf_remove_member(struct vrf_member *vm)
 
 	if (vm == vst->primary_port)
 		vrf_reset_primary(vst);
-
-	if (vst->vrf_empty)
-		return;
-
-	vst->force_active = false;
-	if (vst->n_present == 0)
-		device_set_present(&vst->dev, false);
 }
 
 static void
@@ -536,10 +528,8 @@ vrf_config_init(struct device *dev)
 
 	vst = container_of(dev, struct vrf_state, dev);
 
-	if (vst->vrf_empty) {
-		vst->force_active = true;
-		device_set_present(&vst->dev, true);
-	}
+	vst->force_active = true;
+	device_set_present(&vst->dev, true);
 
 	vst->n_failed = 0;
 	vlist_update(&vst->members);
@@ -558,9 +548,7 @@ vrf_apply_settings(struct vrf_state *vst, struct blob_attr **tb)
 {
 	struct blob_attr *cur;
 
-	vst->vrf_empty = true;
-	// default vrf routing table
-	vst->table = 10;
+	vst->table = 10; /* default VRF routing table */
 	if ((cur = tb[VRF_ATTR_TABLE]))
 		system_resolve_rt_table(blobmsg_data(cur), &vst->table);
 }


### PR DESCRIPTION
VRF support was originally based on bonding.c/bridge.c. Since being added to netifd, fixes have been made that did not make it into vrf.c. Therefore, let's bring in the missing changes.

Commits taken as a basis:
- [device: fix build error on 32 bit systems](https://github.com/openwrt/netifd/commit/40ed7363caf2b22b6e29ed9d9948189c2bc4c8f3)
- [debug: remove newline from debug messages](https://github.com/openwrt/netifd/commit/061e308f9f7d30b0bc490d93e113ee763ecb06a1)
- [bridge: skip present toggle in bridge_free_member() when device is active](https://github.com/openwrt/netifd/commit/69a5afc9713adf31edbf3228a7a372ada7bba449)
- [bridge: remove kernel member on teardown regardless of device claim state](https://github.com/openwrt/netifd/commit/52c7db3a2beb44a0214cae96f9ae6626b525ae84)
- [bridge: attempt delbr unconditionally on bridge destroy](https://github.com/openwrt/netifd/commit/741fd3c162dfa94d4db97f2153748c4595f5929a)
- [bridge: cancel the member retry timer on teardown and free](https://github.com/openwrt/netifd/commit/0bab70f052967d597ada57299c13690edf7c681f)

Also this PR contains next fixes:
- vrf: remove incorrect IPv6 disable on VRF ports
- vrf: remove unused vrf_empty field
- vrf: rename vrf_state_type to vrf_device_type
- vrf: add license header
- system-linux: fix system_vrf_addif retry loop

Fixes: openwrt/openwrt#23829