### PR TITLE
netifd: configure EEE via ethtool netlink

### DIFF
--- a/device.c
+++ b/device.c
@@ -75,6 +75,9 @@ static const struct blobmsg_policy dev_attrs[__DEV_ATTR_MAX] = {
 	[DEV_ATTR_GRO] = { .name = "gro", .type = BLOBMSG_TYPE_BOOL },
 	[DEV_ATTR_MASTER] = { .name = "conduit", .type = BLOBMSG_TYPE_STRING },
 	[DEV_ATTR_EEE] = { .name = "eee", .type = BLOBMSG_TYPE_BOOL },
+	[DEV_ATTR_EEE_TX_LPI] = { .name = "eee_tx_lpi", .type = BLOBMSG_TYPE_BOOL },
+	[DEV_ATTR_EEE_TX_LPI_TIMER] = { .name = "eee_tx_lpi_timer", .type = BLOBMSG_TYPE_INT32 },
+	[DEV_ATTR_EEE_ADVERTISE] = { .name = "eee_advertise", .type = BLOBMSG_TYPE_ARRAY },
 	[DEV_ATTR_TAGS] = { .name = "tags", .type = BLOBMSG_TYPE_ARRAY },
 	[DEV_ATTR_PSE] = { .name = "pse", .type = BLOBMSG_TYPE_BOOL },
 	[DEV_ATTR_PSE_PODL] = { .name = "pse_podl", .type = BLOBMSG_TYPE_BOOL },
@@ -315,6 +318,9 @@ device_merge_settings(struct device *dev, struct device_settings *n)
 	n->autoneg = s->flags & DEV_OPT_AUTONEG ? s->autoneg : os->autoneg;
 	n->gro = s->flags & DEV_OPT_GRO ? s->gro : os->gro;
 	n->eee = s->flags & DEV_OPT_EEE ? s->eee : os->eee;
+	n->eee_tx_lpi = s->flags & DEV_OPT_EEE_TX_LPI ? s->eee_tx_lpi : os->eee_tx_lpi;
+	n->eee_tx_lpi_timer = s->flags & DEV_OPT_EEE_TX_LPI_TIMER ?
+		s->eee_tx_lpi_timer : os->eee_tx_lpi_timer;
 	n->master_ifindex = s->flags & DEV_OPT_MASTER ? s->master_ifindex : os->master_ifindex;
 	n->pse = s->flags & DEV_OPT_PSE ? s->pse : os->pse;
 	n->pse_podl = s->flags & DEV_OPT_PSE_PODL ? s->pse_podl : os->pse_podl;
@@ -589,6 +595,19 @@ device_init_settings(struct device *dev, struct blob_attr **tb)
 		s->flags |= DEV_OPT_EEE;
 	}
 
+	if ((cur = tb[DEV_ATTR_EEE_TX_LPI])) {
+		s->eee_tx_lpi = blobmsg_get_bool(cur);
+		s->flags |= DEV_OPT_EEE_TX_LPI;
+	}
+
+	if ((cur = tb[DEV_ATTR_EEE_TX_LPI_TIMER])) {
+		s->eee_tx_lpi_timer = blobmsg_get_u32(cur);
+		s->flags |= DEV_OPT_EEE_TX_LPI_TIMER;
+	}
+
+	if (tb[DEV_ATTR_EEE_ADVERTISE])
+		s->flags |= DEV_OPT_EEE_ADVERTISE;
+
 	if ((cur = tb[DEV_ATTR_PSE])) {
 		s->pse = blobmsg_get_bool(cur);
 		s->flags |= DEV_OPT_PSE;
@@ -619,6 +638,10 @@ device_init_settings(struct device *dev, struct blob_attr **tb)
 	cur = tb[DEV_ATTR_TAGS];
 	free(dev->tags);
 	dev->tags = cur ? blob_memdup(cur) : NULL;
+
+	cur = tb[DEV_ATTR_EEE_ADVERTISE];
+	free(dev->eee_advertise);
+	dev->eee_advertise = cur ? blob_memdup(cur) : NULL;
 
 	device_set_extra_vlans(dev, tb[DEV_ATTR_VLAN]);
 	device_set_disabled(dev, disabled);
@@ -1121,6 +1144,7 @@ device_free(struct device *dev)
 	free(dev->config);
 	device_cleanup(dev);
 	free(dev->tags);
+	free(dev->eee_advertise);
 	free(dev->config_auth_vlans);
 	free(dev->extra_vlan);
 	dev->type->free(dev);
@@ -1584,6 +1608,12 @@ device_dump_status(struct blob_buf *b, struct device *dev)
 			blobmsg_add_u8(b, "gro", st.gro);
 		if (st.flags & DEV_OPT_EEE)
 			blobmsg_add_u8(b, "eee", st.eee);
+		if (st.flags & DEV_OPT_EEE_TX_LPI)
+			blobmsg_add_u8(b, "eee_tx_lpi", st.eee_tx_lpi);
+		if (st.flags & DEV_OPT_EEE_TX_LPI_TIMER)
+			blobmsg_add_u32(b, "eee_tx_lpi_timer", st.eee_tx_lpi_timer);
+		if (dev->eee_advertise)
+			blobmsg_add_blob(b, dev->eee_advertise);
 	}
 
 	s = blobmsg_open_table(b, "statistics");

--- a/device.h
+++ b/device.h
@@ -77,6 +77,9 @@ enum {
 	DEV_ATTR_GRO,
 	DEV_ATTR_MASTER,
 	DEV_ATTR_EEE,
+	DEV_ATTR_EEE_TX_LPI,
+	DEV_ATTR_EEE_TX_LPI_TIMER,
+	DEV_ATTR_EEE_ADVERTISE,
 	DEV_ATTR_PSE,
 	DEV_ATTR_PSE_PODL,
 	DEV_ATTR_PSE_POWER_LIMIT,
@@ -170,6 +173,9 @@ enum {
 	DEV_OPT_GRO				= 1ULL << DEV_ATTR_GRO,
 	DEV_OPT_MASTER				= 1ULL << DEV_ATTR_MASTER,
 	DEV_OPT_EEE				= 1ULL << DEV_ATTR_EEE,
+	DEV_OPT_EEE_TX_LPI			= 1ULL << DEV_ATTR_EEE_TX_LPI,
+	DEV_OPT_EEE_TX_LPI_TIMER		= 1ULL << DEV_ATTR_EEE_TX_LPI_TIMER,
+	DEV_OPT_EEE_ADVERTISE			= 1ULL << DEV_ATTR_EEE_ADVERTISE,
 	DEV_OPT_PSE				= 1ULL << DEV_ATTR_PSE,
 	DEV_OPT_PSE_PODL			= 1ULL << DEV_ATTR_PSE_PODL,
 	DEV_OPT_PSE_POWER_LIMIT			= 1ULL << DEV_ATTR_PSE_POWER_LIMIT,
@@ -264,6 +270,8 @@ struct device_settings {
 	bool gro;
 	int master_ifindex;
 	bool eee;
+	bool eee_tx_lpi;
+	unsigned int eee_tx_lpi_timer;
 	bool pse;
 	bool pse_podl;
 	unsigned int pse_power_limit;
@@ -290,6 +298,7 @@ struct device {
 	struct blob_attr *config_auth_vlans;
 	struct blob_attr *auth_vlans;
 	struct blob_attr *tags;
+	struct blob_attr *eee_advertise;
 
 	char ifname[IFNAMSIZ];
 	int ifindex;

--- a/system-linux.c
+++ b/system-linux.c
@@ -2138,8 +2138,28 @@ system_set_ethtool_pause(struct device *dev, struct device_settings *s)
 	ioctl(sock_ioctl, SIOCETHTOOL, &ifr);
 }
 
-static void
-system_set_ethtool_eee_settings(struct device *dev, struct device_settings *s)
+struct eth_set_cb_data {
+	int pending;
+	int err;
+};
+
+static int cb_eth_set_ack(struct nl_msg *msg, void *arg)
+{
+	struct eth_set_cb_data *cb_data = arg;
+	cb_data->pending = 0;
+	return NL_STOP;
+}
+
+static int cb_eth_set_error(struct sockaddr_nl *nla, struct nlmsgerr *nlerr, void *arg)
+{
+	struct eth_set_cb_data *cb_data = arg;
+	cb_data->pending = 0;
+	cb_data->err = nlerr->error;
+	return NL_STOP;
+}
+
+static int
+system_set_ethtool_eee_legacy(struct device *dev, struct device_settings *s)
 {
 	struct ethtool_eee eeecmd;
 	struct ifreq ifr = {
@@ -2149,10 +2169,277 @@ system_set_ethtool_eee_settings(struct device *dev, struct device_settings *s)
 	memset(&eeecmd, 0, sizeof(eeecmd));
 	eeecmd.cmd = ETHTOOL_SEEE;
 	eeecmd.eee_enabled = s->eee;
+	if (s->flags & DEV_OPT_EEE_TX_LPI)
+		eeecmd.tx_lpi_enabled = s->eee_tx_lpi;
+	if (s->flags & DEV_OPT_EEE_TX_LPI_TIMER)
+		eeecmd.tx_lpi_timer = s->eee_tx_lpi_timer;
 	strncpy(ifr.ifr_name, dev->ifname, sizeof(ifr.ifr_name) - 1);
 
-	if (ioctl(sock_ioctl, SIOCETHTOOL, &ifr) != 0)
-		netifd_log_message(L_WARNING, "cannot set eee %d for device %s", s->eee, dev->ifname);
+	return ioctl(sock_ioctl, SIOCETHTOOL, &ifr);
+}
+
+struct eth_eee_supported {
+	uint32_t nbits;
+	uint32_t words[16];
+	bool valid;
+};
+
+static int cb_eth_eee_get_reply(struct nl_msg *msg, void *arg)
+{
+	struct eth_eee_supported *out = arg;
+	struct nlmsghdr *nlh = nlmsg_hdr(msg);
+	struct nlattr *tb[ETHTOOL_A_EEE_MAX + 1];
+	struct nlattr *mtb[ETHTOOL_A_BITSET_MAX + 1];
+	struct genlmsghdr *ghdr;
+	uint32_t nbits, nwords;
+	struct nlattr *mask;
+
+	if (nlh->nlmsg_type != ethtool_family)
+		return NL_SKIP;
+
+	ghdr = nlmsg_data(nlh);
+	if (nla_parse(tb, ETHTOOL_A_EEE_MAX, genlmsg_attrdata(ghdr, 0),
+		      genlmsg_attrlen(ghdr, 0), NULL) < 0)
+		return NL_SKIP;
+	if (!tb[ETHTOOL_A_EEE_MODES_OURS])
+		return NL_SKIP;
+	if (nla_parse_nested(mtb, ETHTOOL_A_BITSET_MAX,
+			     tb[ETHTOOL_A_EEE_MODES_OURS], NULL))
+		return NL_SKIP;
+	if (!mtb[ETHTOOL_A_BITSET_SIZE] || !mtb[ETHTOOL_A_BITSET_MASK])
+		return NL_SKIP;
+
+	nbits = nla_get_u32(mtb[ETHTOOL_A_BITSET_SIZE]);
+	nwords = (nbits + 31) / 32;
+	if (nwords > ARRAY_SIZE(out->words))
+		return NL_SKIP;
+
+	mask = mtb[ETHTOOL_A_BITSET_MASK];
+	if (nla_len(mask) < (int)(nwords * sizeof(uint32_t)))
+		return NL_SKIP;
+
+	memcpy(out->words, nla_data(mask), nwords * sizeof(uint32_t));
+	out->nbits = nbits;
+	out->valid = true;
+	return NL_OK;
+}
+
+struct eth_eee_get_cb_data {
+	struct eth_eee_supported *data;
+	int pending;
+	int err;
+};
+
+static int cb_eth_eee_get_ack(struct nl_msg *msg, void *arg)
+{
+	struct eth_eee_get_cb_data *cb_data = arg;
+	cb_data->pending = 0;
+	return NL_STOP;
+}
+
+static int cb_eth_eee_get_error(struct sockaddr_nl *nla,
+				struct nlmsgerr *nlerr, void *arg)
+{
+	struct eth_eee_get_cb_data *cb_data = arg;
+	cb_data->pending = 0;
+	cb_data->err = nlerr->error;
+	return NL_STOP;
+}
+
+static int cb_eth_eee_get_valid(struct nl_msg *msg, void *arg)
+{
+	struct eth_eee_get_cb_data *cb_data = arg;
+	return cb_eth_eee_get_reply(msg, cb_data->data);
+}
+
+static int
+system_get_ethtool_eee_supported(struct device *dev,
+				 struct eth_eee_supported *out)
+{
+	struct eth_eee_get_cb_data cb_data;
+	struct nl_msg *msg = NULL;
+	struct nl_cb *cb = NULL;
+	struct nlattr *hdr;
+	int ret = -ENOMEM;
+
+	memset(out, 0, sizeof(*out));
+
+	if (!sock_genl || ethtool_family < 0)
+		return -EOPNOTSUPP;
+
+	cb = nl_cb_alloc(NL_CB_DEFAULT);
+	msg = nlmsg_alloc();
+	if (!cb || !msg)
+		goto out;
+
+	if (!genlmsg_put(msg, NL_AUTO_PID, NL_AUTO_SEQ, ethtool_family,
+			 0, 0, ETHTOOL_MSG_EEE_GET, 1))
+		goto out;
+
+	hdr = nla_nest_start(msg, ETHTOOL_A_EEE_HEADER);
+	if (!hdr)
+		goto out;
+	nla_put_string(msg, ETHTOOL_A_HEADER_DEV_NAME, dev->ifname);
+	nla_put_u32(msg, ETHTOOL_A_HEADER_FLAGS, ETHTOOL_FLAG_COMPACT_BITSETS);
+	nla_nest_end(msg, hdr);
+
+	cb_data.data = out;
+	cb_data.pending = 1;
+	cb_data.err = 0;
+
+	nl_cb_set(cb, NL_CB_VALID, NL_CB_CUSTOM, cb_eth_eee_get_valid, &cb_data);
+	nl_cb_set(cb, NL_CB_ACK, NL_CB_CUSTOM, cb_eth_eee_get_ack, &cb_data);
+	nl_cb_err(cb, NL_CB_CUSTOM, cb_eth_eee_get_error, &cb_data);
+
+	ret = nl_send_auto_complete(sock_genl, msg);
+	if (ret < 0)
+		goto out;
+
+	while (cb_data.pending > 0) {
+		ret = nl_recvmsgs(sock_genl, cb);
+		if (ret < 0) {
+			cb_data.pending = 0;
+			cb_data.err = ret;
+		}
+	}
+
+	if (cb_data.err)
+		ret = cb_data.err;
+	else
+		ret = out->valid ? 0 : -EOPNOTSUPP;
+
+out:
+	nlmsg_free(msg);
+	nl_cb_put(cb);
+	return ret;
+}
+
+static int
+system_set_ethtool_eee_netlink(struct device *dev, struct device_settings *s)
+{
+	struct eth_eee_supported supported;
+	struct eth_set_cb_data cb_data;
+	bool advertise_all = false;
+	struct nl_msg *msg = NULL;
+	struct nl_cb *cb = NULL;
+	struct nlattr *hdr, *modes_nest, *bits_nest;
+	int ret = -ENOMEM;
+
+	if (!sock_genl || ethtool_family < 0)
+		return -EOPNOTSUPP;
+
+	if (!(s->flags & DEV_OPT_EEE_ADVERTISE) &&
+	    (s->flags & DEV_OPT_EEE) && s->eee &&
+	    system_get_ethtool_eee_supported(dev, &supported) == 0 &&
+	    supported.nbits > 0)
+		advertise_all = true;
+
+	cb = nl_cb_alloc(NL_CB_DEFAULT);
+	msg = nlmsg_alloc();
+	if (!cb || !msg)
+		goto out;
+
+	if (!genlmsg_put(msg, NL_AUTO_PID, NL_AUTO_SEQ, ethtool_family,
+			 0, 0, ETHTOOL_MSG_EEE_SET, 1))
+		goto out;
+
+	hdr = nla_nest_start(msg, ETHTOOL_A_EEE_HEADER);
+	if (!hdr)
+		goto out;
+	nla_put_string(msg, ETHTOOL_A_HEADER_DEV_NAME, dev->ifname);
+	nla_nest_end(msg, hdr);
+
+	if (s->flags & DEV_OPT_EEE)
+		nla_put_u8(msg, ETHTOOL_A_EEE_ENABLED, s->eee);
+
+	if (s->flags & DEV_OPT_EEE_TX_LPI)
+		nla_put_u8(msg, ETHTOOL_A_EEE_TX_LPI_ENABLED, s->eee_tx_lpi);
+
+	if (s->flags & DEV_OPT_EEE_TX_LPI_TIMER)
+		nla_put_u32(msg, ETHTOOL_A_EEE_TX_LPI_TIMER, s->eee_tx_lpi_timer);
+
+	if (dev->eee_advertise) {
+		struct blob_attr *cur;
+		size_t rem;
+
+		modes_nest = nla_nest_start(msg, ETHTOOL_A_EEE_MODES_OURS);
+		if (!modes_nest)
+			goto out;
+		nla_put_flag(msg, ETHTOOL_A_BITSET_NOMASK);
+		bits_nest = nla_nest_start(msg, ETHTOOL_A_BITSET_BITS);
+		if (!bits_nest)
+			goto out;
+		blobmsg_for_each_attr(cur, dev->eee_advertise, rem) {
+			struct nlattr *bit;
+
+			if (blobmsg_type(cur) != BLOBMSG_TYPE_STRING)
+				continue;
+			bit = nla_nest_start(msg, ETHTOOL_A_BITSET_BITS_BIT);
+			if (!bit)
+				goto out;
+			nla_put_string(msg, ETHTOOL_A_BITSET_BIT_NAME,
+				       blobmsg_get_string(cur));
+			nla_nest_end(msg, bit);
+		}
+		nla_nest_end(msg, bits_nest);
+		nla_nest_end(msg, modes_nest);
+	} else if (advertise_all) {
+		uint32_t nwords = (supported.nbits + 31) / 32;
+
+		modes_nest = nla_nest_start(msg, ETHTOOL_A_EEE_MODES_OURS);
+		if (!modes_nest)
+			goto out;
+		nla_put_flag(msg, ETHTOOL_A_BITSET_NOMASK);
+		nla_put_u32(msg, ETHTOOL_A_BITSET_SIZE, supported.nbits);
+		nla_put(msg, ETHTOOL_A_BITSET_VALUE,
+			nwords * sizeof(uint32_t), supported.words);
+		nla_nest_end(msg, modes_nest);
+	}
+
+	cb_data.pending = 1;
+	cb_data.err = 0;
+
+	nl_cb_set(cb, NL_CB_ACK, NL_CB_CUSTOM, cb_eth_set_ack, &cb_data);
+	nl_cb_err(cb, NL_CB_CUSTOM, cb_eth_set_error, &cb_data);
+
+	ret = nl_send_auto_complete(sock_genl, msg);
+	if (ret < 0)
+		goto out;
+
+	while (cb_data.pending > 0) {
+		ret = nl_recvmsgs(sock_genl, cb);
+		if (ret < 0) {
+			cb_data.pending = 0;
+			cb_data.err = ret;
+		}
+	}
+
+	ret = cb_data.err;
+
+out:
+	nlmsg_free(msg);
+	nl_cb_put(cb);
+	return ret;
+}
+
+static void
+system_set_ethtool_eee_settings(struct device *dev, struct device_settings *s)
+{
+	int ret;
+
+	ret = system_set_ethtool_eee_netlink(dev, s);
+	if (!ret)
+		return;
+
+	if (ret != -EOPNOTSUPP && ret != -ENOSYS)
+		netifd_log_message(L_NOTICE,
+			"EEE: netlink set failed for %s (%d), trying legacy ioctl",
+			dev->ifname, ret);
+
+	if (system_set_ethtool_eee_legacy(dev, s) != 0)
+		netifd_log_message(L_WARNING,
+			"cannot set eee %d for device %s (netlink ret %d)",
+			s->eee, dev->ifname, ret);
 }
 
 /*
@@ -2313,32 +2600,12 @@ static int system_pse_get(struct device *dev, struct pse_reply_data *data)
 	return data->valid ? 0 : -EOPNOTSUPP;
 }
 
-struct pse_set_cb_data {
-	int pending;
-	int err;
-};
-
-static int cb_pse_set_ack(struct nl_msg *msg, void *arg)
-{
-	struct pse_set_cb_data *cb_data = arg;
-	cb_data->pending = 0;
-	return NL_STOP;
-}
-
-static int cb_pse_set_error(struct sockaddr_nl *nla, struct nlmsgerr *nlerr, void *arg)
-{
-	struct pse_set_cb_data *cb_data = arg;
-	cb_data->pending = 0;
-	cb_data->err = nlerr->error;
-	return NL_STOP;
-}
-
 static int system_pse_set(struct device *dev, struct device_settings *s)
 {
 	struct nl_msg *msg;
 	struct nlattr *hdr;
 	struct nl_cb *cb;
-	struct pse_set_cb_data cb_data;
+	struct eth_set_cb_data cb_data;
 	int ret;
 
 	/* Early return if no PSE settings requested */
@@ -2396,8 +2663,8 @@ static int system_pse_set(struct device *dev, struct device_settings *s)
 	cb_data.pending = 1;
 	cb_data.err = 0;
 
-	nl_cb_set(cb, NL_CB_ACK, NL_CB_CUSTOM, cb_pse_set_ack, &cb_data);
-	nl_cb_err(cb, NL_CB_CUSTOM, cb_pse_set_error, &cb_data);
+	nl_cb_set(cb, NL_CB_ACK, NL_CB_CUSTOM, cb_eth_set_ack, &cb_data);
+	nl_cb_err(cb, NL_CB_CUSTOM, cb_eth_set_error, &cb_data);
 
 	ret = nl_send_auto_complete(sock_genl, msg);
 	nlmsg_free(msg);
@@ -2440,9 +2707,6 @@ system_set_ethtool_settings(struct device *dev, struct device_settings *s)
 	__u32 *supported, *advertising;
 
 	system_set_ethtool_pause(dev, s);
-
-	if (s->flags & DEV_OPT_EEE)
-		system_set_ethtool_eee_settings(dev, s);
 
 	/* Apply PSE (PoE) settings if configured */
 	if (s->flags & (DEV_OPT_PSE | DEV_OPT_PSE_PODL | DEV_OPT_PSE_POWER_LIMIT | DEV_OPT_PSE_PRIORITY))
@@ -2514,6 +2778,10 @@ system_set_ethtool_settings(struct device *dev, struct device_settings *s)
 static void
 system_set_ethtool_settings_after_up(struct device *dev, struct device_settings *s)
 {
+	if (s->flags & (DEV_OPT_EEE | DEV_OPT_EEE_TX_LPI |
+			DEV_OPT_EEE_TX_LPI_TIMER | DEV_OPT_EEE_ADVERTISE))
+		system_set_ethtool_eee_settings(dev, s);
+
 	if (s->flags & DEV_OPT_GRO)
 		system_set_ethtool_gro(dev, s);
 }
@@ -2769,7 +3037,7 @@ system_if_apply_settings(struct device *dev, struct device_settings *s, uint64_t
 	if (apply_mask & (DEV_OPT_SPEED | DEV_OPT_DUPLEX |
 			  DEV_OPT_PAUSE | DEV_OPT_ASYM_PAUSE |
 			  DEV_OPT_RXPAUSE | DEV_OPT_TXPAUSE |
-			  DEV_OPT_AUTONEG | DEV_OPT_EEE |
+			  DEV_OPT_AUTONEG |
 			  DEV_OPT_PSE | DEV_OPT_PSE_PODL |
 			  DEV_OPT_PSE_POWER_LIMIT | DEV_OPT_PSE_PRIORITY))
 		system_set_ethtool_settings(dev, s);


### PR DESCRIPTION
The legacy ETHTOOL_SEEE ioctl is rejected by phylink-based PHY drivers that only implement the netlink set_eee path.

Switch the EEE setter to ETHTOOL_MSG_EEE_SET, falling back to the legacy ioctl when genetlink is unavailable. Expose tx_lpi, tx_lpi_timer, and advertised modes as config device options so the full netlink interface is reachable from UCI.

When eee=1 without an explicit eee_advertise list, query the PHY's supported EEE modes via ETHTOOL_MSG_EEE_GET and advertise that set.

Send MODES_OURS with NOMASK so the kernel replaces the previously advertised bitmap rather than merging with it.