### PR TITLE
port-split: add optional devlink port split support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ ENDIF()
 
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 
+OPTION(DEVLINK_PORT_SPLIT "Enable devlink port split support" OFF)
+
 SET(SOURCES
 	main.c utils.c system.c tunnel.c handler.c
 	interface.c interface-ip.c interface-event.c
@@ -40,6 +42,11 @@ FIND_PATH(ubox_include_dir libubox/usock.h)
 FIND_PATH(ucode_include_dir ucode/vm.h)
 FIND_PATH(udebug_include_dir udebug.h)
 INCLUDE_DIRECTORIES(${ubox_include_dir} ${ucode_include_dir})
+
+IF(DEVLINK_PORT_SPLIT)
+	ADD_DEFINITIONS(-DDEVLINK_PORT_SPLIT)
+	SET(SOURCES ${SOURCES} port-split.c)
+ENDIF()
 
 IF (NOT DEFINED LIBNL_LIBS)
 	include(FindPkgConfig)

--- a/config.c
+++ b/config.c
@@ -30,6 +30,10 @@
 #include "system.h"
 #include "ucode.h"
 
+#ifdef DEVLINK_PORT_SPLIT
+#include "port-split.h"
+#endif
+
 bool config_init = false;
 
 static struct uci_context *uci_ctx;
@@ -807,6 +811,9 @@ config_init_all(void)
 	config_init = true;
 
 	device_reset_config();
+#ifdef DEVLINK_PORT_SPLIT
+	port_split_config_init(uci_ctx, uci_network);
+#endif
 	config_load_vlans();
 	config_init_devices(true);
 	config_init_vlans();

--- a/main.c
+++ b/main.c
@@ -28,6 +28,10 @@
 #include "extdev.h"
 #include "ucode.h"
 
+#ifdef DEVLINK_PORT_SPLIT
+#include "port-split.h"
+#endif
+
 unsigned int debug_mask = 0;
 const char *main_path = DEFAULT_MAIN_PATH;
 const char *config_path = DEFAULT_CONFIG_PATH;
@@ -270,6 +274,9 @@ netifd_kill_process(struct netifd_process *proc)
 
 static void netifd_do_restart(struct uloop_timeout *timeout)
 {
+#ifdef DEVLINK_PORT_SPLIT
+	port_split_shutdown();
+#endif
 	execvp(global_argv[0], global_argv);
 }
 

--- a/port-split.c
+++ b/port-split.c
@@ -1,0 +1,281 @@
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <uci.h>
+
+#include "netifd.h"
+#include "port-split.h"
+#include "system.h"
+
+#define PORT_SPLIT_WAIT_TIMEOUT_MS 2000
+
+struct port_split_config {
+	struct list_head list;
+	char *device;
+	uint32_t count;
+	bool ignore;
+	bool done;
+};
+
+struct port_split_state {
+	struct list_head list;
+	char *device;
+	uint32_t count;
+	uint32_t split_group;
+	struct system_devlink_port parent;
+	struct system_devlink_port member;
+};
+
+static LIST_HEAD(port_split_states);
+
+static bool
+port_split_parse_count(const char *str, uint32_t *count)
+{
+	char *end;
+	unsigned long val;
+
+	errno = 0;
+	val = strtoul(str, &end, 0);
+	if (errno || end == str || *end || val > UINT32_MAX)
+		return false;
+
+	*count = val;
+	return true;
+}
+
+static struct port_split_config *
+port_split_config_find(struct list_head *configs, const char *device)
+{
+	struct port_split_config *cfg;
+
+	list_for_each_entry(cfg, configs, list)
+		if (!strcmp(cfg->device, device))
+			return cfg;
+
+	return NULL;
+}
+
+static struct port_split_state *
+port_split_state_find(const char *device)
+{
+	struct port_split_state *st;
+
+	list_for_each_entry(st, &port_split_states, list)
+		if (!strcmp(st->device, device))
+			return st;
+
+	return NULL;
+}
+
+static void
+port_split_config_add(struct list_head *configs, const char *device,
+		      uint32_t count, bool ignore)
+{
+	struct port_split_config *cfg;
+
+	cfg = port_split_config_find(configs, device);
+	if (!cfg) {
+		cfg = calloc(1, sizeof(*cfg));
+		if (!cfg)
+			return;
+
+		cfg->device = strdup(device);
+		if (!cfg->device) {
+			free(cfg);
+			return;
+		}
+
+		list_add_tail(&cfg->list, configs);
+	}
+
+	cfg->count = count;
+	cfg->ignore = ignore;
+}
+
+static void
+port_split_config_load(struct uci_context *ctx, struct uci_package *pkg,
+		       struct list_head *configs)
+{
+	struct uci_element *e;
+
+	uci_foreach_element(&pkg->sections, e) {
+		struct uci_section *s = uci_to_section(e);
+		const char *device, *split;
+		uint32_t count;
+
+		if (strcmp(s->type, "device") != 0)
+			continue;
+
+		device = uci_lookup_option_string(ctx, s, "name");
+		split = uci_lookup_option_string(ctx, s, "split");
+		if (!device || !split)
+			continue;
+
+		if (!port_split_parse_count(split, &count)) {
+			netifd_log_message(L_WARNING,
+					   "%s: invalid port split count '%s'\n",
+					   device, split);
+			port_split_config_add(configs, device, 0, true);
+			continue;
+		}
+
+		port_split_config_add(configs, device, count >= 2 ? count : 0,
+				      false);
+	}
+}
+
+static void
+port_split_state_free(struct port_split_state *st)
+{
+	list_del(&st->list);
+	free(st->device);
+	free(st);
+}
+
+static void
+port_split_config_free(struct port_split_config *cfg)
+{
+	list_del(&cfg->list);
+	free(cfg->device);
+	free(cfg);
+}
+
+static int
+port_split_unsplit_state(struct port_split_state *st)
+{
+	int ret;
+
+	ret = system_devlink_port_unsplit(&st->member);
+	if (ret) {
+		netifd_log_message(L_WARNING,
+				   "%s: failed to unsplit managed devlink group %u (%d)\n",
+				   st->device, st->split_group, ret);
+		return ret;
+	}
+
+	ret = system_devlink_port_wait_ifname(st->device, &st->parent,
+					       PORT_SPLIT_WAIT_TIMEOUT_MS);
+	if (ret)
+		netifd_log_message(L_WARNING,
+				   "%s: parent netdev did not reappear after unsplit (%d)\n",
+				   st->device, ret);
+
+	return 0;
+}
+
+static void
+port_split_apply_config(struct port_split_config *cfg)
+{
+	struct port_split_state *st;
+	int ret;
+
+	if (port_split_state_find(cfg->device)) {
+		cfg->done = true;
+		return;
+	}
+
+	st = calloc(1, sizeof(*st));
+	if (!st)
+		return;
+
+	st->device = strdup(cfg->device);
+	if (!st->device) {
+		free(st);
+		return;
+	}
+
+	ret = system_devlink_port_from_ifname(cfg->device, &st->parent);
+	if (ret) {
+		netifd_log_message(L_WARNING,
+				   "%s: unable to resolve devlink port for split (%d)\n",
+				   cfg->device, ret);
+		goto error;
+	}
+
+	ret = system_devlink_port_split(&st->parent, cfg->count, &st->member,
+					&st->split_group);
+	if (ret) {
+		netifd_log_message(L_WARNING,
+				   "%s: failed to split devlink port into %u ports (%d)\n",
+				   cfg->device, cfg->count, ret);
+		goto error;
+	}
+
+	st->count = cfg->count;
+	list_add_tail(&st->list, &port_split_states);
+	cfg->done = true;
+	return;
+
+error:
+	free(st->device);
+	free(st);
+}
+
+void
+port_split_config_init(struct uci_context *ctx, struct uci_package *pkg)
+{
+	LIST_HEAD(configs);
+	struct port_split_state *st, *st_tmp;
+	struct port_split_config *cfg, *cfg_tmp;
+
+	if (!pkg)
+		return;
+
+	port_split_config_load(ctx, pkg, &configs);
+
+	list_for_each_entry_safe(st, st_tmp, &port_split_states, list) {
+		cfg = port_split_config_find(&configs, st->device);
+		if (!cfg) {
+			if (!port_split_unsplit_state(st))
+				port_split_state_free(st);
+			continue;
+		}
+
+		if (cfg->ignore) {
+			cfg->done = true;
+			continue;
+		}
+
+		if (!cfg->count) {
+			cfg->done = true;
+			if (!port_split_unsplit_state(st))
+				port_split_state_free(st);
+			continue;
+		}
+
+		if (cfg->count == st->count) {
+			cfg->done = true;
+			continue;
+		}
+
+		if (!port_split_unsplit_state(st))
+			port_split_state_free(st);
+		else
+			cfg->done = true;
+	}
+
+	list_for_each_entry(cfg, &configs, list) {
+		if (cfg->ignore || cfg->done || !cfg->count)
+			continue;
+
+		port_split_apply_config(cfg);
+	}
+
+	list_for_each_entry_safe(cfg, cfg_tmp, &configs, list)
+		port_split_config_free(cfg);
+}
+
+void
+port_split_shutdown(void)
+{
+	struct port_split_state *st, *tmp;
+
+	list_for_each_entry_safe(st, tmp, &port_split_states, list) {
+		if (!port_split_unsplit_state(st))
+			port_split_state_free(st);
+	}
+}

--- a/port-split.h
+++ b/port-split.h
@@ -1,0 +1,22 @@
+#ifndef __NETIFD_PORT_SPLIT_H
+#define __NETIFD_PORT_SPLIT_H
+
+struct uci_context;
+struct uci_package;
+
+#ifdef DEVLINK_PORT_SPLIT
+void port_split_config_init(struct uci_context *ctx, struct uci_package *pkg);
+void port_split_shutdown(void);
+#else
+static inline void
+port_split_config_init(struct uci_context *ctx, struct uci_package *pkg)
+{
+}
+
+static inline void
+port_split_shutdown(void)
+{
+}
+#endif
+
+#endif

--- a/system-dummy.c
+++ b/system-dummy.c
@@ -31,6 +31,35 @@ int system_init(void)
 	return 0;
 }
 
+#ifdef DEVLINK_PORT_SPLIT
+int system_devlink_port_from_ifname(const char *ifname,
+				    struct system_devlink_port *port)
+{
+	return 0;
+}
+
+int system_devlink_port_wait_ifname(const char *ifname,
+				    struct system_devlink_port *port,
+				    unsigned int timeout_ms)
+{
+	return 0;
+}
+
+int system_devlink_port_split(const struct system_devlink_port *port,
+			      uint32_t count,
+			      struct system_devlink_port *member,
+			      uint32_t *split_group)
+{
+	return 0;
+}
+
+int system_devlink_port_unsplit(const struct system_devlink_port *port)
+{
+	return 0;
+}
+
+#endif
+
 int system_bridge_addbr(struct device *bridge, struct bridge_config *cfg)
 {
 	return 0;

--- a/system-linux.c
+++ b/system-linux.c
@@ -48,6 +48,10 @@
 #include <linux/veth.h>
 #include <linux/version.h>
 
+#ifdef DEVLINK_PORT_SPLIT
+#include <linux/devlink.h>
+#endif
+
 #include <sched.h>
 
 #include "ethtool-modes.h"
@@ -69,6 +73,7 @@
 #include <glob.h>
 #include <time.h>
 #include <unistd.h>
+#include <poll.h>
 
 #include <netlink/msg.h>
 #include <netlink/attr.h>
@@ -94,6 +99,9 @@ static int sock_ioctl = -1;
 static struct nl_sock *sock_rtnl = NULL;
 static struct nl_sock *sock_genl = NULL;
 static int ethtool_family = -1;
+#ifdef DEVLINK_PORT_SPLIT
+static int devlink_family_id = -1;
+#endif
 
 static int cb_rtnl_event(struct nl_msg *msg, void *arg);
 static void handle_hotplug_event(struct uloop_fd *u, unsigned int events);
@@ -235,6 +243,599 @@ create_socket(int protocol, int groups)
 
 	return sock;
 }
+
+#ifdef DEVLINK_PORT_SPLIT
+struct system_devlink_split_group {
+	uint32_t group;
+	struct system_devlink_port member;
+};
+
+struct system_devlink_lookup_data {
+	struct system_devlink_port *port;
+	int pending;
+	int ret;
+};
+
+struct system_devlink_ifname_wait {
+	const char *ifname;
+	struct system_devlink_port *port;
+	bool done;
+	int ret;
+};
+
+struct system_devlink_group_dump {
+	const struct system_devlink_port *parent;
+	struct system_devlink_split_group *groups;
+	size_t len;
+	size_t count;
+	int pending;
+	int ret;
+};
+
+static int
+system_devlink_get_family(void)
+{
+	if (devlink_family_id >= 0)
+		return devlink_family_id;
+
+	if (!sock_genl) {
+		sock_genl = create_socket(NETLINK_GENERIC, 0);
+		if (!sock_genl)
+			return -1;
+	}
+
+	devlink_family_id = genl_ctrl_resolve(sock_genl, DEVLINK_GENL_NAME);
+	return devlink_family_id;
+}
+
+static struct nl_msg *
+system_devlink_msg(int cmd, uint16_t flags)
+{
+	struct nl_msg *msg;
+	int family;
+
+	family = system_devlink_get_family();
+	if (family < 0)
+		return NULL;
+
+	msg = nlmsg_alloc();
+	if (!msg)
+		return NULL;
+
+	if (!genlmsg_put(msg, 0, 0, family, 0, flags, cmd,
+			 DEVLINK_GENL_VERSION)) {
+		nlmsg_free(msg);
+		return NULL;
+	}
+
+	return msg;
+}
+
+static int
+system_devlink_call(struct nl_msg *msg)
+{
+	int ret;
+
+	ret = nl_send_auto_complete(sock_genl, msg);
+	nlmsg_free(msg);
+	if (ret < 0)
+		return ret;
+
+	return nl_wait_for_ack(sock_genl);
+}
+
+static int
+system_devlink_copy_string(char *dst, size_t dst_len, struct nlattr *attr)
+{
+	const char *str = nla_get_string(attr);
+
+	if (strlen(str) >= dst_len)
+		return -ENAMETOOLONG;
+
+	snprintf(dst, dst_len, "%s", str);
+	return 0;
+}
+
+static int
+system_devlink_parse_handle(struct nlattr **tb,
+			    struct system_devlink_port *port)
+{
+	int ret;
+
+	if (!tb[DEVLINK_ATTR_BUS_NAME] || !tb[DEVLINK_ATTR_DEV_NAME] ||
+	    !tb[DEVLINK_ATTR_PORT_INDEX])
+		return -ENOENT;
+
+	ret = system_devlink_copy_string(port->bus_name, sizeof(port->bus_name),
+					 tb[DEVLINK_ATTR_BUS_NAME]);
+	if (ret)
+		return ret;
+
+	ret = system_devlink_copy_string(port->dev_name, sizeof(port->dev_name),
+					 tb[DEVLINK_ATTR_DEV_NAME]);
+	if (ret)
+		return ret;
+
+	port->port_index = nla_get_u32(tb[DEVLINK_ATTR_PORT_INDEX]);
+	return 0;
+}
+
+static int
+system_devlink_lookup_valid(struct nl_msg *msg, void *arg)
+{
+	struct system_devlink_lookup_data *data = arg;
+	struct nlmsghdr *nh = nlmsg_hdr(msg);
+	struct ifinfomsg *ifi = NLMSG_DATA(nh);
+	struct nlattr *tb[__IFLA_MAX];
+	struct nlattr *dl[DEVLINK_ATTR_MAX + 1];
+
+	if (nh->nlmsg_type != RTM_NEWLINK)
+		return NL_SKIP;
+
+	if (ifi->ifi_family != AF_UNSPEC)
+		return NL_SKIP;
+
+	memset(tb, 0, sizeof(tb));
+	nlmsg_parse(nh, sizeof(struct ifinfomsg), tb, __IFLA_MAX - 1, NULL);
+	if (!tb[IFLA_DEVLINK_PORT]) {
+		data->ret = -EOPNOTSUPP;
+		return NL_OK;
+	}
+
+	memset(dl, 0, sizeof(dl));
+	if (nla_parse_nested(dl, DEVLINK_ATTR_MAX, tb[IFLA_DEVLINK_PORT], NULL)) {
+		data->ret = -EINVAL;
+		return NL_OK;
+	}
+
+	data->ret = system_devlink_parse_handle(dl, data->port);
+	return NL_OK;
+}
+
+static int
+system_devlink_lookup_ack(struct nl_msg *msg, void *arg)
+{
+	struct system_devlink_lookup_data *data = arg;
+
+	data->pending = 0;
+	return NL_STOP;
+}
+
+static int
+system_devlink_lookup_error(struct sockaddr_nl *nla, struct nlmsgerr *err,
+			    void *arg)
+{
+	struct system_devlink_lookup_data *data = arg;
+
+	data->ret = err->error;
+	data->pending = 0;
+	return NL_STOP;
+}
+
+int
+system_devlink_port_from_ifname(const char *ifname,
+				struct system_devlink_port *port)
+{
+	struct system_devlink_lookup_data data = {
+		.port = port,
+		.pending = 1,
+		.ret = -ENOENT,
+	};
+	struct nl_cb *cb = nl_cb_alloc(NL_CB_DEFAULT);
+	struct ifinfomsg ifi = {
+		.ifi_family = AF_UNSPEC,
+		.ifi_index = 0,
+	};
+	struct nl_msg *msg;
+	int ret;
+
+	if (!cb || !ifname || !port)
+		goto out;
+
+	msg = nlmsg_alloc_simple(RTM_GETLINK, NLM_F_REQUEST);
+	if (!msg)
+		goto out;
+
+	if (nlmsg_append(msg, &ifi, sizeof(ifi), 0) ||
+	    nla_put_string(msg, IFLA_IFNAME, ifname))
+		goto free;
+
+	nl_cb_set(cb, NL_CB_VALID, NL_CB_CUSTOM,
+		  system_devlink_lookup_valid, &data);
+	nl_cb_set(cb, NL_CB_ACK, NL_CB_CUSTOM,
+		  system_devlink_lookup_ack, &data);
+	nl_cb_err(cb, NL_CB_CUSTOM, system_devlink_lookup_error, &data);
+
+	ret = nl_send_auto_complete(sock_rtnl, msg);
+	if (ret < 0) {
+		data.ret = ret;
+		goto free;
+	}
+
+	while (data.pending > 0) {
+		ret = nl_recvmsgs(sock_rtnl, cb);
+		if (ret < 0) {
+			data.ret = ret;
+			break;
+		}
+	}
+
+free:
+	nlmsg_free(msg);
+out:
+	if (cb)
+		nl_cb_put(cb);
+	return data.ret;
+}
+
+static unsigned int
+system_devlink_elapsed_ms(const struct timespec *start)
+{
+	struct timespec now;
+	uint64_t elapsed;
+
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	elapsed = (uint64_t)(now.tv_sec - start->tv_sec) * 1000;
+	elapsed += (now.tv_nsec - start->tv_nsec) / 1000000;
+
+	return elapsed > UINT_MAX ? UINT_MAX : elapsed;
+}
+
+static int
+system_devlink_wait_valid(struct nl_msg *msg, void *arg)
+{
+	struct system_devlink_ifname_wait *data = arg;
+	struct nlmsghdr *nh = nlmsg_hdr(msg);
+	struct ifinfomsg *ifi = NLMSG_DATA(nh);
+	struct nlattr *tb[__IFLA_MAX];
+	struct nlattr *dl[DEVLINK_ATTR_MAX + 1];
+	const char *ifname;
+	int ret;
+
+	if (nh->nlmsg_type != RTM_NEWLINK)
+		return NL_SKIP;
+
+	if (ifi->ifi_family != AF_UNSPEC)
+		return NL_SKIP;
+
+	memset(tb, 0, sizeof(tb));
+	nlmsg_parse(nh, sizeof(struct ifinfomsg), tb, __IFLA_MAX - 1, NULL);
+	if (!tb[IFLA_IFNAME])
+		return NL_SKIP;
+
+	ifname = nla_get_string(tb[IFLA_IFNAME]);
+	if (strcmp(ifname, data->ifname))
+		return NL_SKIP;
+
+	if (tb[IFLA_DEVLINK_PORT]) {
+		memset(dl, 0, sizeof(dl));
+		if (nla_parse_nested(dl, DEVLINK_ATTR_MAX, tb[IFLA_DEVLINK_PORT], NULL))
+			data->ret = -EINVAL;
+		else
+			data->ret = system_devlink_parse_handle(dl, data->port);
+	} else {
+		ret = system_devlink_port_from_ifname(data->ifname, data->port);
+		if (ret && ret != -EOPNOTSUPP)
+			return NL_OK;
+
+		data->ret = ret;
+	}
+
+	data->done = true;
+	return NL_STOP;
+}
+
+static int
+system_devlink_wait_error(struct sockaddr_nl *nla, struct nlmsgerr *err,
+			  void *arg)
+{
+	struct system_devlink_ifname_wait *data = arg;
+
+	data->ret = err->error;
+	data->done = true;
+	return NL_STOP;
+}
+
+static int
+system_devlink_wait_seq_check(struct nl_msg *msg, void *arg)
+{
+	return NL_OK;
+}
+
+int
+system_devlink_port_wait_ifname(const char *ifname,
+				struct system_devlink_port *port,
+				unsigned int timeout_ms)
+{
+	struct system_devlink_ifname_wait data = {
+		.ifname = ifname,
+		.port = port,
+		.ret = -ETIMEDOUT,
+	};
+	struct pollfd pfd = { .events = POLLIN };
+	struct timespec start;
+	struct nl_sock *sock;
+	struct nl_cb *cb;
+	unsigned int elapsed;
+	int ret;
+
+	if (!ifname || !port)
+		return -EINVAL;
+
+	sock = create_socket(NETLINK_ROUTE, 0);
+	if (!sock)
+		return system_devlink_port_from_ifname(ifname, port);
+
+	ret = nl_socket_add_membership(sock, RTNLGRP_LINK);
+	if (ret < 0) {
+		nl_socket_free(sock);
+		return ret;
+	}
+
+	cb = nl_cb_alloc(NL_CB_DEFAULT);
+	if (!cb) {
+		nl_socket_free(sock);
+		return -ENOMEM;
+	}
+
+	nl_cb_set(cb, NL_CB_VALID, NL_CB_CUSTOM,
+		  system_devlink_wait_valid, &data);
+	nl_cb_set(cb, NL_CB_SEQ_CHECK, NL_CB_CUSTOM,
+		  system_devlink_wait_seq_check, NULL);
+	nl_cb_err(cb, NL_CB_CUSTOM, system_devlink_wait_error, &data);
+
+	ret = system_devlink_port_from_ifname(ifname, port);
+	if (!ret || ret == -EOPNOTSUPP) {
+		data.ret = ret;
+		goto out;
+	}
+
+	clock_gettime(CLOCK_MONOTONIC, &start);
+	pfd.fd = nl_socket_get_fd(sock);
+
+	while (!data.done) {
+		elapsed = system_devlink_elapsed_ms(&start);
+		if (elapsed >= timeout_ms)
+			break;
+
+		ret = poll(&pfd, 1, timeout_ms - elapsed);
+		if (ret < 0) {
+			if (errno == EINTR)
+				continue;
+
+			data.ret = -errno;
+			break;
+		}
+
+		if (!ret)
+			break;
+
+		ret = nl_recvmsgs(sock, cb);
+		if (ret < 0) {
+			data.ret = ret;
+			break;
+		}
+	}
+
+out:
+	nl_cb_put(cb);
+	nl_socket_free(sock);
+	return data.ret;
+}
+
+static bool
+system_devlink_group_seen(struct system_devlink_split_group *groups,
+			  size_t count, uint32_t group)
+{
+	size_t i;
+
+	for (i = 0; i < count; i++)
+		if (groups[i].group == group)
+			return true;
+
+	return false;
+}
+
+static int
+system_devlink_group_valid(struct nl_msg *msg, void *arg)
+{
+	struct system_devlink_group_dump *data = arg;
+	struct system_devlink_port port;
+	struct nlmsghdr *nh = nlmsg_hdr(msg);
+	struct nlattr *tb[DEVLINK_ATTR_MAX + 1];
+	uint32_t group;
+	int ret;
+
+	memset(tb, 0, sizeof(tb));
+	if (genlmsg_parse(nh, 0, tb, DEVLINK_ATTR_MAX, NULL))
+		return NL_SKIP;
+
+	if (!tb[DEVLINK_ATTR_PORT_SPLIT_GROUP])
+		return NL_SKIP;
+
+	ret = system_devlink_parse_handle(tb, &port);
+	if (ret)
+		return NL_SKIP;
+
+	if (strcmp(port.bus_name, data->parent->bus_name) ||
+	    strcmp(port.dev_name, data->parent->dev_name))
+		return NL_SKIP;
+
+	group = nla_get_u32(tb[DEVLINK_ATTR_PORT_SPLIT_GROUP]);
+	if (system_devlink_group_seen(data->groups, data->count, group))
+		return NL_SKIP;
+
+	if (data->count >= data->len) {
+		data->ret = -ENOSPC;
+		data->pending = 0;
+		return NL_STOP;
+	}
+
+	data->groups[data->count].group = group;
+	data->groups[data->count].member = port;
+	data->count++;
+	return NL_OK;
+}
+
+static int
+system_devlink_group_done(struct nl_msg *msg, void *arg)
+{
+	struct system_devlink_group_dump *data = arg;
+
+	data->pending = 0;
+	return NL_STOP;
+}
+
+static int
+system_devlink_group_error(struct sockaddr_nl *nla, struct nlmsgerr *err,
+			   void *arg)
+{
+	struct system_devlink_group_dump *data = arg;
+
+	data->ret = err->error;
+	data->pending = 0;
+	return NL_STOP;
+}
+
+static int
+system_devlink_dump_split_groups(const struct system_devlink_port *parent,
+				 struct system_devlink_split_group *groups,
+				 size_t *count)
+{
+	struct system_devlink_group_dump data = {
+		.parent = parent,
+		.groups = groups,
+		.len = *count,
+		.pending = 1,
+	};
+	struct nl_cb *cb = nl_cb_alloc(NL_CB_DEFAULT);
+	struct nl_msg *msg;
+	int ret;
+
+	*count = 0;
+	if (!cb)
+		return -ENOMEM;
+
+	msg = system_devlink_msg(DEVLINK_CMD_PORT_GET,
+				  NLM_F_REQUEST | NLM_F_DUMP);
+	if (!msg) {
+		ret = -1;
+		goto out;
+	}
+
+	nl_cb_set(cb, NL_CB_VALID, NL_CB_CUSTOM,
+		  system_devlink_group_valid, &data);
+	nl_cb_set(cb, NL_CB_FINISH, NL_CB_CUSTOM,
+		  system_devlink_group_done, &data);
+	nl_cb_set(cb, NL_CB_ACK, NL_CB_CUSTOM,
+		  system_devlink_group_done, &data);
+	nl_cb_err(cb, NL_CB_CUSTOM, system_devlink_group_error, &data);
+
+	ret = nl_send_auto_complete(sock_genl, msg);
+	nlmsg_free(msg);
+	if (ret < 0)
+		goto out;
+
+	while (data.pending > 0) {
+		ret = nl_recvmsgs(sock_genl, cb);
+		if (ret < 0) {
+			data.ret = ret;
+			break;
+		}
+	}
+
+	*count = data.count;
+	ret = data.ret;
+
+out:
+	nl_cb_put(cb);
+	return ret;
+}
+
+static int
+system_devlink_port_cmd(const struct system_devlink_port *port, int cmd,
+			uint32_t count)
+{
+	struct nl_msg *msg;
+
+	msg = system_devlink_msg(cmd, NLM_F_REQUEST | NLM_F_ACK);
+	if (!msg)
+		return -1;
+
+	if (nla_put_string(msg, DEVLINK_ATTR_BUS_NAME, port->bus_name) ||
+	    nla_put_string(msg, DEVLINK_ATTR_DEV_NAME, port->dev_name) ||
+	    nla_put_u32(msg, DEVLINK_ATTR_PORT_INDEX, port->port_index)) {
+		nlmsg_free(msg);
+		return -ENOMEM;
+	}
+
+	if (count && nla_put_u32(msg, DEVLINK_ATTR_PORT_SPLIT_COUNT, count)) {
+		nlmsg_free(msg);
+		return -ENOMEM;
+	}
+
+	return system_devlink_call(msg);
+}
+
+int
+system_devlink_port_split(const struct system_devlink_port *port,
+			  uint32_t count,
+			  struct system_devlink_port *member,
+			  uint32_t *split_group)
+{
+	struct system_devlink_split_group *before, *after;
+	size_t before_count = 256;
+	size_t after_count = 256;
+	size_t i;
+	int ret = -ENOMEM;
+
+	if (!port || !member || !split_group || count < 2)
+		return -EINVAL;
+
+	before = calloc(before_count, sizeof(*before));
+	after = calloc(after_count, sizeof(*after));
+	if (!before || !after)
+		goto out;
+
+	ret = system_devlink_dump_split_groups(port, before, &before_count);
+	if (ret)
+		goto out;
+
+	ret = system_devlink_port_cmd(port, DEVLINK_CMD_PORT_SPLIT, count);
+	if (ret)
+		goto out;
+
+	ret = system_devlink_dump_split_groups(port, after, &after_count);
+	if (ret)
+		goto out;
+
+	ret = -ENOENT;
+	for (i = 0; i < after_count; i++) {
+		if (system_devlink_group_seen(before, before_count, after[i].group))
+			continue;
+
+		*member = after[i].member;
+		*split_group = after[i].group;
+		ret = 0;
+		break;
+	}
+
+out:
+	free(before);
+	free(after);
+	return ret;
+}
+
+int
+system_devlink_port_unsplit(const struct system_devlink_port *port)
+{
+	if (!port)
+		return -EINVAL;
+
+	return system_devlink_port_cmd(port, DEVLINK_CMD_PORT_UNSPLIT, 0);
+}
+
+#endif
 
 static bool
 create_raw_event_socket(struct event_socket *ev, int protocol, int groups,

--- a/system.h
+++ b/system.h
@@ -324,6 +324,26 @@ int system_link_netns_move(struct device *dev, const pid_t target_ns, const char
 int system_netns_open(const pid_t target_ns);
 int system_netns_set(int netns_fd);
 
+#ifdef DEVLINK_PORT_SPLIT
+struct system_devlink_port {
+	char bus_name[32];
+	char dev_name[128];
+	uint32_t port_index;
+};
+
+int system_devlink_port_from_ifname(const char *ifname,
+				    struct system_devlink_port *port);
+int system_devlink_port_wait_ifname(const char *ifname,
+				    struct system_devlink_port *port,
+				    unsigned int timeout_ms);
+int system_devlink_port_split(const struct system_devlink_port *port,
+			      uint32_t count,
+			      struct system_devlink_port *member,
+			      uint32_t *split_group);
+int system_devlink_port_unsplit(const struct system_devlink_port *port);
+
+#endif
+
 #ifndef SYSTEM_IMPL
 #include "system-log.h"
 #endif


### PR DESCRIPTION
Add support for configuring devlink port splitting from network device
sections using a device split option, e.g.:

```
config device
      option name 'swp1'
      option split '4'
```

Port splitting is commonly used on network switches where a front panel
port can be split into multiple links with a breakout cable.

The feature is disabled by default to minimize overhead on other device/targets
and can be enabled with `CONFIG_NETIFD_DEVLINK_PORT_SPLIT`.

Run tested on a Mellanox Spectrum SN3420.