### PR TITLE
container related fixes and additions

### DIFF
--- a/bridge.c
+++ b/bridge.c
@@ -1046,7 +1046,8 @@ bridge_free(struct device *dev)
 
 	system_bridge_delbr(dev);
 
-	kvlist_free(&dev->vlan_aliases);
+	if (dev->vlan_aliases.get_len)
+		kvlist_free(&dev->vlan_aliases);
 	free(bst->config_data);
 	free(bst);
 }

--- a/bridge.c
+++ b/bridge.c
@@ -1055,7 +1055,8 @@ bridge_free(struct device *dev)
 
 	system_bridge_delbr(dev);
 
-	kvlist_free(&dev->vlan_aliases);
+	if (dev->vlan_aliases.get_len)
+		kvlist_free(&dev->vlan_aliases);
 	free(bst->config_data);
 	free(bst);
 }

--- a/device.c
+++ b/device.c
@@ -1456,8 +1456,10 @@ device_create(const char *name, struct device_type *type,
 		return NULL;
 
 	dev = type->create(name, type, config);
-	if (!dev)
+	if (!dev) {
+		free(config);
 		return NULL;
+	}
 
 	dev->current_config = true;
 	dev->config = config;

--- a/device.c
+++ b/device.c
@@ -1406,7 +1406,8 @@ device_reset_config(void)
 	struct device *dev;
 
 	avl_for_each_element(&devices, dev, avl)
-		dev->current_config = false;
+		if (!dev->dynamic)
+			dev->current_config = false;
 }
 
 void

--- a/device.c
+++ b/device.c
@@ -1435,7 +1435,8 @@ device_reset_config(void)
 	struct device *dev;
 
 	avl_for_each_element(&devices, dev, avl)
-		dev->current_config = false;
+		if (!dev->dynamic)
+			dev->current_config = false;
 }
 
 void

--- a/device.h
+++ b/device.h
@@ -313,6 +313,7 @@ struct device {
 	bool current_config;
 	bool iface_config;
 	bool default_config;
+	bool dynamic;
 	bool wireless;
 	bool wireless_ap;
 	bool wireless_proxyarp;

--- a/device.h
+++ b/device.h
@@ -319,6 +319,7 @@ struct device {
 	bool current_config;
 	bool iface_config;
 	bool default_config;
+	bool dynamic;
 	bool wireless;
 	bool wireless_ap;
 	bool wireless_proxyarp;

--- a/interface.c
+++ b/interface.c
@@ -58,6 +58,7 @@ enum {
 	IFACE_ATTR_FORCE_LINK,
 	IFACE_ATTR_IP6WEIGHT,
 	IFACE_ATTR_TAGS,
+	IFACE_ATTR_PERSISTENT,
 	IFACE_ATTR_MAX
 };
 
@@ -89,6 +90,7 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_FORCE_LINK] = { .name = "force_link", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_IP6WEIGHT] = { .name = "ip6weight", .type = BLOBMSG_TYPE_INT32 },
 	[IFACE_ATTR_TAGS] = { .name = "tags", .type = BLOBMSG_TYPE_ARRAY },
+	[IFACE_ATTR_PERSISTENT] = { .name = "persistent", .type = BLOBMSG_TYPE_BOOL },
 };
 
 const struct uci_blob_param_list interface_attr_list = {
@@ -100,6 +102,8 @@ static void
 interface_set_main_dev(struct interface *iface, struct device *dev);
 static void
 interface_event(struct interface *iface, enum interface_event ev);
+static void
+interface_handle_config_change(struct interface *iface);
 
 static void
 interface_error_flush(struct interface *iface)
@@ -376,7 +380,7 @@ interface_check_state(struct interface *iface)
 	case IFS_SETUP:
 		if (!iface->enabled || !link_state) {
 			iface->state = IFS_TEARDOWN;
-			if (iface->dynamic)
+			if (iface->dynamic && (!iface->persistent || !iface->enabled))
 				__set_config_state(iface, IFC_REMOVE);
 
 			interface_proto_event(iface->proto, PROTO_CMD_TEARDOWN, false);
@@ -442,9 +446,11 @@ interface_jail_pending_clear(struct interface *iface)
 static void
 interface_main_dev_cb(struct device_user *dep, enum device_event ev)
 {
+	enum interface_state state;
 	struct interface *iface;
 
 	iface = container_of(dep, struct interface, main_dev);
+	state = iface->state;
 	switch (ev) {
 	case DEV_EVENT_ADD:
 		interface_set_available(iface, true);
@@ -456,6 +462,24 @@ interface_main_dev_cb(struct device_user *dep, enum device_event ev)
 		interface_set_available(iface, false);
 		if (dep->dev && dep->dev->external && !dep->dev->sys_present)
 			interface_set_main_dev(iface, NULL);
+
+		if (!iface->dynamic || !iface->persistent)
+			break;
+
+		/* persistent interfaces skip self-removal on teardown, remove
+		 * them here instead once the device itself is gone */
+		switch (state) {
+		case IFS_DOWN:
+			__set_config_state(iface, IFC_REMOVE);
+			interface_handle_config_change(iface);
+			break;
+		case IFS_TEARDOWN:
+			if (iface->config_state == IFC_NORMAL)
+				__set_config_state(iface, IFC_REMOVE);
+			break;
+		default:
+			break;
+		}
 		break;
 	case DEV_EVENT_UP:
 		interface_set_enabled(iface, true);
@@ -884,6 +908,7 @@ interface_alloc(const char *name, struct blob_attr *config, bool dynamic)
 	iface->renew = blobmsg_get_bool_default(tb[IFACE_ATTR_RENEW], true);
 	iface->force_link = blobmsg_get_bool_default(tb[IFACE_ATTR_FORCE_LINK], force_link);
 	iface->dynamic = dynamic;
+	iface->persistent = blobmsg_get_bool_default(tb[IFACE_ATTR_PERSISTENT], false);
 	iface->proto_ip.no_defaultroute =
 		!blobmsg_get_bool_default(tb[IFACE_ATTR_DEFAULTROUTE], true);
 	iface->proto_ip.no_dns =
@@ -1389,6 +1414,7 @@ interface_change_config(struct interface *if_old, struct interface *if_new)
 	if_old->device = if_new->device;
 	if_old->parent_ifname = if_new->parent_ifname;
 	if_old->dynamic = if_new->dynamic;
+	if_old->persistent = if_new->persistent;
 	if_old->proto_handler = if_new->proto_handler;
 	if_old->force_link = if_new->force_link;
 	if_old->dns_metric = if_new->dns_metric;

--- a/interface.c
+++ b/interface.c
@@ -430,6 +430,16 @@ interface_ext_dev_cb(struct device_user *dep, enum device_event ev)
 }
 
 static void
+interface_jail_pending_clear(struct interface *iface)
+{
+	if (iface->netns_fd >= 0) {
+		close(iface->netns_fd);
+		iface->netns_fd = -1;
+	}
+	iface->jail_pending = false;
+}
+
+static void
 interface_main_dev_cb(struct device_user *dep, enum device_event ev)
 {
 	struct interface *iface;
@@ -438,6 +448,9 @@ interface_main_dev_cb(struct device_user *dep, enum device_event ev)
 	switch (ev) {
 	case DEV_EVENT_ADD:
 		interface_set_available(iface, true);
+		if (iface->jail_pending &&
+		    !system_link_netns_move(iface->main_dev.dev, iface->netns_fd, iface->jail_device))
+			interface_jail_pending_clear(iface);
 		break;
 	case DEV_EVENT_REMOVE:
 		interface_set_available(iface, false);
@@ -709,6 +722,8 @@ void interface_free(struct interface *iface)
 	free(iface->jail);
 	free(iface->jail_device);
 	free(iface->host_device);
+	if (iface->netns_fd >= 0)
+		close(iface->netns_fd);
 	free(iface);
 }
 
@@ -838,6 +853,7 @@ interface_alloc(const char *name, struct blob_attr *config, bool dynamic)
 	avl_init(&iface->data, avl_strcmp, false, NULL);
 	iface->config_ip.enabled = false;
 
+	iface->netns_fd = -1;
 	iface->main_dev.cb = interface_main_dev_cb;
 	iface->l3_dev.cb = interface_l3_dev_cb;
 	iface->ext_dev.cb = interface_ext_dev_cb;
@@ -1207,7 +1223,15 @@ interface_start_jail(int netns_fd, const char *jail)
 		if (!iface->jail || strcmp(iface->jail, jail))
 			continue;
 
-		system_link_netns_move(iface->main_dev.dev, netns_fd, iface->jail_device);
+		interface_jail_pending_clear(iface);
+
+		if (!system_link_netns_move(iface->main_dev.dev, netns_fd, iface->jail_device))
+			continue;
+
+		/* device not present yet: keep a reference to the jail netns and
+		 * complete the move once the device shows up (DEV_EVENT_ADD). */
+		iface->netns_fd = dup(netns_fd);
+		iface->jail_pending = iface->netns_fd >= 0;
 	}
 }
 
@@ -1218,6 +1242,10 @@ interface_stop_jail(int netns_fd)
 	char *orig_ifname;
 
 	vlist_for_each_element(&interfaces, iface, node) {
+		if (iface->jail_pending) {
+			interface_jail_pending_clear(iface);
+			continue;
+		}
 		orig_ifname = iface->host_device;
 		interface_set_down(iface);
 		system_link_netns_move(iface->main_dev.dev, netns_fd, orig_ifname);

--- a/interface.c
+++ b/interface.c
@@ -728,13 +728,22 @@ void interface_free(struct interface *iface)
 }
 
 static void
+interface_free_cb(struct uloop_timeout *timeout)
+{
+	struct interface *iface = container_of(timeout, struct interface, remove_timer);
+
+	interface_free(iface);
+}
+
+static void
 interface_do_remove(struct interface *iface)
 {
 	interface_event(iface, IFEV_FREE);
 	interface_cleanup(iface);
 	netifd_ubus_remove_interface(iface);
 	avl_delete(&interfaces.avl, &iface->node.avl);
-	interface_free(iface);
+	iface->remove_timer.cb = interface_free_cb;
+	uloop_timeout_set(&iface->remove_timer, 1);
 }
 
 static void

--- a/interface.c
+++ b/interface.c
@@ -77,6 +77,7 @@ enum {
 	IFACE_ATTR_IP6WEIGHT,
 	IFACE_ATTR_TAGS,
 	IFACE_ATTR_CARRIER_LOSS_DELAY,
+	IFACE_ATTR_PERSISTENT,
 	IFACE_ATTR_MAX
 };
 
@@ -109,6 +110,7 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_IP6WEIGHT] = { .name = "ip6weight", .type = BLOBMSG_TYPE_INT32 },
 	[IFACE_ATTR_TAGS] = { .name = "tags", .type = BLOBMSG_TYPE_ARRAY },
 	[IFACE_ATTR_CARRIER_LOSS_DELAY] = { .name = "carrier_loss_delay", .type = BLOBMSG_TYPE_INT32 },
+	[IFACE_ATTR_PERSISTENT] = { .name = "persistent", .type = BLOBMSG_TYPE_BOOL },
 };
 
 const struct uci_blob_param_list interface_attr_list = {
@@ -402,7 +404,7 @@ interface_check_state(struct interface *iface)
 		if (!iface->enabled || !link_state) {
 			uloop_timeout_cancel(&iface->carrier_loss_timer);
 			iface->state = IFS_TEARDOWN;
-			if (iface->dynamic)
+			if (iface->dynamic && (!iface->persistent || !iface->enabled))
 				__set_config_state(iface, IFC_REMOVE);
 
 			interface_proto_event(iface->proto, PROTO_CMD_TEARDOWN, false);
@@ -502,9 +504,11 @@ interface_jail_pending_clear(struct interface *iface)
 static void
 interface_main_dev_cb(struct device_user *dep, enum device_event ev)
 {
+	enum interface_state state;
 	struct interface *iface;
 
 	iface = container_of(dep, struct interface, main_dev);
+	state = iface->state;
 	switch (ev) {
 	case DEV_EVENT_ADD:
 		interface_set_available(iface, true);
@@ -516,6 +520,23 @@ interface_main_dev_cb(struct device_user *dep, enum device_event ev)
 		interface_set_available(iface, false);
 		if (dep->dev && dep->dev->external && !dep->dev->sys_present)
 			interface_set_main_dev(iface, NULL);
+
+		if (!iface->dynamic || !iface->persistent)
+			break;
+
+		/* persistent interfaces skip self-removal on teardown, remove
+		 * them here instead once the device itself is gone */
+		switch (state) {
+		case IFS_DOWN:
+			set_config_state(iface, IFC_REMOVE);
+			break;
+		case IFS_TEARDOWN:
+			if (iface->config_state == IFC_NORMAL)
+				__set_config_state(iface, IFC_REMOVE);
+			break;
+		default:
+			break;
+		}
 		break;
 	case DEV_EVENT_UP:
 		interface_set_enabled(iface, true);
@@ -991,6 +1012,7 @@ interface_alloc(const char *name, struct blob_attr *config, bool dynamic)
 		iface->carrier_loss_delay = delay;
 	}
 	iface->dynamic = dynamic;
+	iface->persistent = blobmsg_get_bool_default(tb[IFACE_ATTR_PERSISTENT], false);
 	iface->proto_ip.no_defaultroute =
 		!blobmsg_get_bool_default(tb[IFACE_ATTR_DEFAULTROUTE], true);
 	iface->proto_ip.no_dns =
@@ -1630,6 +1652,7 @@ interface_change_config(struct interface *if_old, struct interface *if_new)
 	if_old->device = if_new->device;
 	if_old->parent_ifname = if_new->parent_ifname;
 	if_old->dynamic = if_new->dynamic;
+	if_old->persistent = if_new->persistent;
 	if_old->proto_handler = if_new->proto_handler;
 	if_old->force_link = if_new->force_link;
 	if_old->carrier_loss_delay = if_new->carrier_loss_delay;

--- a/interface.c
+++ b/interface.c
@@ -266,7 +266,7 @@ int interface_parse_data(struct interface *iface, const struct blob_attr *attr)
 
 	iface->updated = 0;
 
-	blob_for_each_attr(cur, attr, rem) {
+	blobmsg_for_each_attr(cur, attr, rem) {
 		ret = interface_add_data(iface, cur);
 		if (ret)
 			return ret;

--- a/interface.c
+++ b/interface.c
@@ -490,6 +490,16 @@ interface_ext_dev_cb(struct device_user *dep, enum device_event ev)
 }
 
 static void
+interface_jail_pending_clear(struct interface *iface)
+{
+	if (iface->netns_fd >= 0) {
+		close(iface->netns_fd);
+		iface->netns_fd = -1;
+	}
+	iface->jail_pending = false;
+}
+
+static void
 interface_main_dev_cb(struct device_user *dep, enum device_event ev)
 {
 	struct interface *iface;
@@ -498,6 +508,9 @@ interface_main_dev_cb(struct device_user *dep, enum device_event ev)
 	switch (ev) {
 	case DEV_EVENT_ADD:
 		interface_set_available(iface, true);
+		if (iface->jail_pending &&
+		    !system_link_netns_move(iface->main_dev.dev, iface->netns_fd, iface->jail_device))
+			interface_jail_pending_clear(iface);
 		break;
 	case DEV_EVENT_REMOVE:
 		interface_set_available(iface, false);
@@ -792,6 +805,8 @@ void interface_free(struct interface *iface)
 	free(iface->jail);
 	free(iface->jail_device);
 	free(iface->host_device);
+	if (iface->netns_fd >= 0)
+		close(iface->netns_fd);
 	free(iface);
 }
 
@@ -947,6 +962,7 @@ interface_alloc(const char *name, struct blob_attr *config, bool dynamic)
 	avl_init(&iface->data, avl_strcmp, false, NULL);
 	iface->config_ip.enabled = false;
 
+	iface->netns_fd = -1;
 	iface->main_dev.cb = interface_main_dev_cb;
 	iface->l3_dev.cb = interface_l3_dev_cb;
 	iface->ext_dev.cb = interface_ext_dev_cb;
@@ -1451,7 +1467,15 @@ interface_start_jail(int netns_fd, const char *jail)
 		if (!iface->jail || strcmp(iface->jail, jail))
 			continue;
 
-		system_link_netns_move(iface->main_dev.dev, netns_fd, iface->jail_device);
+		interface_jail_pending_clear(iface);
+
+		if (!system_link_netns_move(iface->main_dev.dev, netns_fd, iface->jail_device))
+			continue;
+
+		/* device not present yet: keep a reference to the jail netns and
+		 * complete the move once the device shows up (DEV_EVENT_ADD). */
+		iface->netns_fd = dup(netns_fd);
+		iface->jail_pending = iface->netns_fd >= 0;
 	}
 }
 
@@ -1462,6 +1486,10 @@ interface_stop_jail(int netns_fd)
 	char *orig_ifname;
 
 	vlist_for_each_element(&interfaces, iface, node) {
+		if (iface->jail_pending) {
+			interface_jail_pending_clear(iface);
+			continue;
+		}
 		orig_ifname = iface->host_device;
 		interface_set_down(iface);
 		system_link_netns_move(iface->main_dev.dev, netns_fd, orig_ifname);

--- a/interface.h
+++ b/interface.h
@@ -113,6 +113,7 @@ struct interface {
 	char *jail_device;
 	char *host_device;
 	int netns_fd;
+	bool jail_pending;
 
 	bool available;
 	bool autostart;

--- a/interface.h
+++ b/interface.h
@@ -123,6 +123,7 @@ struct interface {
 	bool link_state;
 	bool force_link;
 	bool dynamic;
+	bool persistent;
 	bool policy_rules_set;
 	bool link_up_event;
 	bool renew;

--- a/system-linux.c
+++ b/system-linux.c
@@ -1670,6 +1670,9 @@ int system_link_netns_move(struct device *dev, int netns_fd, const char *target_
 		return -1;
 
 	index = system_if_resolve(dev);
+	if (index <= 0)
+		return -1;
+
 	msg = __system_ifinfo_msg(AF_UNSPEC, index, target_ifname, RTM_NEWLINK, 0);
 	if (!msg)
 		return -1;

--- a/system-linux.c
+++ b/system-linux.c
@@ -1741,6 +1741,9 @@ int system_link_netns_move(struct device *dev, int netns_fd, const char *target_
 		return -1;
 
 	index = system_if_resolve(dev);
+	if (index <= 0)
+		return -1;
+
 	msg = __system_ifinfo_msg(AF_UNSPEC, index, target_ifname, RTM_NEWLINK, 0);
 	if (!msg)
 		return -1;

--- a/ubus.c
+++ b/ubus.c
@@ -892,6 +892,7 @@ netifd_dump_status(struct interface *iface)
 	blobmsg_add_u8(&b, "available", iface->available);
 	blobmsg_add_u8(&b, "autostart", iface->autostart);
 	blobmsg_add_u8(&b, "dynamic", iface->dynamic);
+	blobmsg_add_u8(&b, "persistent", iface->persistent);
 
 	if (iface->state == IFS_UP) {
 		time_t cur = system_get_rtime();

--- a/ubus.c
+++ b/ubus.c
@@ -19,6 +19,7 @@
 
 #include "netifd.h"
 #include "interface.h"
+#include "device.h"
 #include "proto.h"
 #include "ubus.h"
 #include "system.h"
@@ -202,12 +203,88 @@ netifd_netns_updown(struct ubus_context *ctx, struct ubus_object *obj,
 	return UBUS_STATUS_OK;
 }
 
+enum {
+	CDEV_NAME,
+	CDEV_TYPE,
+	__CDEV_MAX
+};
+
+static const struct blobmsg_policy create_device_policy[__CDEV_MAX] = {
+	[CDEV_NAME] = { .name = "name", .type = BLOBMSG_TYPE_STRING },
+	[CDEV_TYPE] = { .name = "type", .type = BLOBMSG_TYPE_STRING },
+};
+
+static int
+netifd_create_device(struct ubus_context *ctx, struct ubus_object *obj,
+		     struct ubus_request_data *req, const char *method,
+		     struct blob_attr *msg)
+{
+	struct blob_attr *tb[__CDEV_MAX];
+	struct device_type *type;
+	struct device *dev;
+
+	blobmsg_parse_attr(create_device_policy, __CDEV_MAX, tb, msg);
+
+	if (!tb[CDEV_NAME] || !tb[CDEV_TYPE])
+		return UBUS_STATUS_INVALID_ARGUMENT;
+
+	type = device_type_get(blobmsg_get_string(tb[CDEV_TYPE]));
+	if (!type || !type->create)
+		return UBUS_STATUS_NOT_SUPPORTED;
+
+	dev = device_create(blobmsg_get_string(tb[CDEV_NAME]), type, msg);
+	if (!dev)
+		return UBUS_STATUS_UNKNOWN_ERROR;
+
+	dev->dynamic = true;
+
+	return UBUS_STATUS_OK;
+}
+
+enum {
+	DDEV_NAME,
+	__DDEV_MAX
+};
+
+static const struct blobmsg_policy delete_device_policy[__DDEV_MAX] = {
+	[DDEV_NAME] = { .name = "name", .type = BLOBMSG_TYPE_STRING },
+};
+
+static int
+netifd_delete_device(struct ubus_context *ctx, struct ubus_object *obj,
+		     struct ubus_request_data *req, const char *method,
+		     struct blob_attr *msg)
+{
+	struct blob_attr *tb[__DDEV_MAX];
+	struct device *dev;
+
+	blobmsg_parse_attr(delete_device_policy, __DDEV_MAX, tb, msg);
+
+	if (!tb[DDEV_NAME])
+		return UBUS_STATUS_INVALID_ARGUMENT;
+
+	dev = device_find(blobmsg_get_string(tb[DDEV_NAME]));
+	if (!dev)
+		return UBUS_STATUS_NOT_FOUND;
+
+	if (!dev->dynamic)
+		return UBUS_STATUS_PERMISSION_DENIED;
+
+	dev->dynamic = false;
+	dev->current_config = false;
+	device_free_unused();
+
+	return UBUS_STATUS_OK;
+}
+
 static struct ubus_method main_object_methods[] = {
 	{ .name = "restart", .handler = netifd_handle_restart },
 	{ .name = "reload", .handler = netifd_handle_reload },
 	UBUS_METHOD("add_host_route", netifd_add_host_route, route_policy),
 	{ .name = "get_proto_handlers", .handler = netifd_get_proto_handlers },
 	UBUS_METHOD("add_dynamic", netifd_add_dynamic, dynamic_policy),
+	UBUS_METHOD("create_device", netifd_create_device, create_device_policy),
+	UBUS_METHOD("delete_device", netifd_delete_device, delete_device_policy),
 	UBUS_METHOD("netns_updown", netifd_netns_updown, netns_updown_policy),
 };
 

--- a/ubus.c
+++ b/ubus.c
@@ -908,6 +908,7 @@ netifd_dump_status(struct interface *iface)
 	blobmsg_add_u8(&b, "available", iface->available);
 	blobmsg_add_u8(&b, "autostart", iface->autostart);
 	blobmsg_add_u8(&b, "dynamic", iface->dynamic);
+	blobmsg_add_u8(&b, "persistent", iface->persistent);
 
 	if (iface->state == IFS_UP) {
 		time_t cur = system_get_rtime();

--- a/ubus.c
+++ b/ubus.c
@@ -120,11 +120,13 @@ netifd_get_proto_handlers(struct ubus_context *ctx, struct ubus_object *obj,
 
 enum {
 	DI_NAME,
+	DI_DATA,
 	__DI_MAX
 };
 
 static const struct blobmsg_policy dynamic_policy[__DI_MAX] = {
 	[DI_NAME] = { .name = "name", .type = BLOBMSG_TYPE_STRING },
+	[DI_DATA] = { .name = "data", .type = BLOBMSG_TYPE_TABLE },
 };
 
 static int
@@ -135,6 +137,8 @@ netifd_add_dynamic(struct ubus_context *ctx, struct ubus_object *obj,
 	struct blob_attr *tb[__DI_MAX];
 	struct interface *iface;
 	struct blob_attr *config;
+	struct blob_attr *cur;
+	size_t rem;
 
 	blobmsg_parse_attr(dynamic_policy, __DI_MAX, tb, msg);
 
@@ -142,6 +146,13 @@ netifd_add_dynamic(struct ubus_context *ctx, struct ubus_object *obj,
 		return UBUS_STATUS_INVALID_ARGUMENT;
 
 	const char *name = blobmsg_get_string(tb[DI_NAME]);
+
+	if (tb[DI_DATA]) {
+		blobmsg_for_each_attr(cur, tb[DI_DATA], rem) {
+			if (!blobmsg_check_attr(cur, true))
+				return UBUS_STATUS_INVALID_ARGUMENT;
+		}
+	}
 
 	iface = interface_alloc(name, msg, true);
 	if (!iface)
@@ -153,6 +164,12 @@ netifd_add_dynamic(struct ubus_context *ctx, struct ubus_object *obj,
 
 	if (!interface_add(iface, config))
 		goto error_free_config;
+
+	if (tb[DI_DATA]) {
+		iface = vlist_find(&interfaces, name, iface, node);
+		if (iface)
+			return interface_parse_data(iface, tb[DI_DATA]);
+	}
 
 	return UBUS_STATUS_OK;
 

--- a/ubus.c
+++ b/ubus.c
@@ -19,6 +19,7 @@
 
 #include "netifd.h"
 #include "interface.h"
+#include "device.h"
 #include "proto.h"
 #include "ubus.h"
 #include "system.h"
@@ -204,12 +205,88 @@ netifd_netns_updown(struct ubus_context *ctx, struct ubus_object *obj,
 	return UBUS_STATUS_OK;
 }
 
+enum {
+	CDEV_NAME,
+	CDEV_TYPE,
+	__CDEV_MAX
+};
+
+static const struct blobmsg_policy create_device_policy[__CDEV_MAX] = {
+	[CDEV_NAME] = { .name = "name", .type = BLOBMSG_TYPE_STRING },
+	[CDEV_TYPE] = { .name = "type", .type = BLOBMSG_TYPE_STRING },
+};
+
+static int
+netifd_create_device(struct ubus_context *ctx, struct ubus_object *obj,
+		     struct ubus_request_data *req, const char *method,
+		     struct blob_attr *msg)
+{
+	struct blob_attr *tb[__CDEV_MAX];
+	struct device_type *type;
+	struct device *dev;
+
+	blobmsg_parse_attr(create_device_policy, __CDEV_MAX, tb, msg);
+
+	if (!tb[CDEV_NAME] || !tb[CDEV_TYPE])
+		return UBUS_STATUS_INVALID_ARGUMENT;
+
+	type = device_type_get(blobmsg_get_string(tb[CDEV_TYPE]));
+	if (!type || !type->create)
+		return UBUS_STATUS_NOT_SUPPORTED;
+
+	dev = device_create(blobmsg_get_string(tb[CDEV_NAME]), type, msg);
+	if (!dev)
+		return UBUS_STATUS_UNKNOWN_ERROR;
+
+	dev->dynamic = true;
+
+	return UBUS_STATUS_OK;
+}
+
+enum {
+	DDEV_NAME,
+	__DDEV_MAX
+};
+
+static const struct blobmsg_policy delete_device_policy[__DDEV_MAX] = {
+	[DDEV_NAME] = { .name = "name", .type = BLOBMSG_TYPE_STRING },
+};
+
+static int
+netifd_delete_device(struct ubus_context *ctx, struct ubus_object *obj,
+		     struct ubus_request_data *req, const char *method,
+		     struct blob_attr *msg)
+{
+	struct blob_attr *tb[__DDEV_MAX];
+	struct device *dev;
+
+	blobmsg_parse_attr(delete_device_policy, __DDEV_MAX, tb, msg);
+
+	if (!tb[DDEV_NAME])
+		return UBUS_STATUS_INVALID_ARGUMENT;
+
+	dev = device_find(blobmsg_get_string(tb[DDEV_NAME]));
+	if (!dev)
+		return UBUS_STATUS_NOT_FOUND;
+
+	if (!dev->dynamic)
+		return UBUS_STATUS_PERMISSION_DENIED;
+
+	dev->dynamic = false;
+	dev->current_config = false;
+	device_free_unused();
+
+	return UBUS_STATUS_OK;
+}
+
 static struct ubus_method main_object_methods[] = {
 	{ .name = "restart", .handler = netifd_handle_restart },
 	{ .name = "reload", .handler = netifd_handle_reload },
 	UBUS_METHOD("add_host_route", netifd_add_host_route, route_policy),
 	{ .name = "get_proto_handlers", .handler = netifd_get_proto_handlers },
 	UBUS_METHOD("add_dynamic", netifd_add_dynamic, dynamic_policy),
+	UBUS_METHOD("create_device", netifd_create_device, create_device_policy),
+	UBUS_METHOD("delete_device", netifd_delete_device, delete_device_policy),
 	UBUS_METHOD("netns_updown", netifd_netns_updown, netns_updown_policy),
 };
 


### PR DESCRIPTION
Fix bugs affecting container network setup and expose the remaining ubus surface an external manager needs to wire up containers without taking the (problematic) detour via UCI:

* `create_device` and `delete_device` on the `network` object allow assembling ephemeral devices such as veth pairs or bridges entirely over ubus, with no persistent `config device` section. Runtime-created devices are exempt from the config reload sweep, mirroring how `add_dynamic` interfaces survive a reload.
* A `persistent` flag on `add_dynamic` (default off) keeps a dynamic interface across bare carrier loss; it is only removed once its device actually goes away. Without it, a veth feeding a container whose peer has not gained carrier yet is destroyed while still needed, and an external manager re-adding it churns.
* `add_dynamic` now accepts an optional `data` table, so an interface can be created with e.g. its firewall zone membership and rule data attached atomically. Previously the caller had to follow up with `set_data`, and a firewall reload landing between the two calls observed the interface without any data.
* Bug fixes for the jail netns move paths and for a crash when freeing a runtime-created bridge whose vlan_aliases kvlist was never initialised.

v2:
* rebased onto current master
* dropped "interface: defer freeing of removed interfaces" and "device: do not leak the config blob when device creation fails", superseded by e2f28e5 ("interface: defer interface removal to avoid use-after-free") and 684dc2d ("device: fix error handling in device_create") respectively
* reworked "interface: keep persistent dynamic interfaces on carrier loss" on top of the deferred interface removal machinery
* added "ubus: allow supplying interface data in add_dynamic"